### PR TITLE
Add resource group management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ There are probably tons of typos, ambiguities or other oddities, you are welcome
 - Azure Compute Gallery: `imagegallery` -> `list `
 - Azure Compute Gallery Images: `imagegallery images` -> `list`
 - Management Group:  `mg` -> `show`
+- Resource Groups: `rg` -> `list | create | show | delete` (filter and export supported)
 - Virtual Machines:  `vm` -> `list | start | stop | restart | delete`
 - Virtual Machines Scale Sets: `vmss` -> `list | start | stop | restart | delete | changeimage | reimage | upgrade`
 - Virtual Machines Scale Sets Instance:  `vmss instance` -> `list | start | stop | restart | reimage | upgrade`

--- a/src/Commands/mg/MGShowCommand.cs
+++ b/src/Commands/mg/MGShowCommand.cs
@@ -38,15 +38,21 @@ namespace AzureOpsCLI.Commands.mg
 
 
             var managementGroupStructure = await _mgService.FetchManagementGroupsAsync();
+            if (managementGroupStructure == null || !managementGroupStructure.Any())
+            {
+                AnsiConsole.MarkupLine("[red]No management groups were returned. Ensure you have access and that management groups are enabled for the tenant.[/]");
+                return -1;
+            }
+
             var rootTree = new Tree("[green]Management Groups[/]");
 
             var groupLookup = managementGroupStructure.ToDictionary(mg => mg.DisplayName, mg => mg);
 
-            var rootGroup = managementGroupStructure.FirstOrDefault(mg => mg.DisplayName == "Tenant Root Group");
+            var rootGroup = managementGroupStructure.FirstOrDefault(mg => mg.Parent == "None");
 
             if (rootGroup == null)
             {
-                AnsiConsole.MarkupLine("[red]Error[/]: Root management group (Tenant Root Group) not found.");
+                AnsiConsole.MarkupLine("[red]Error[/]: Root management group not found or you do not have permission to view it. Verify that the Management Groups feature is enabled and that you have at least Reader access to the root group.");
                 return -1;
             }
 

--- a/src/Commands/rg/RGCreateSubscriptionCommand.cs
+++ b/src/Commands/rg/RGCreateSubscriptionCommand.cs
@@ -1,0 +1,56 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.rg
+{
+    public class RGCreateSubscriptionCommand : AsyncCommand<RGCreateSubscriptionCommand.Settings>
+    {
+        private readonly IRGService _rgService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public RGCreateSubscriptionCommand(IRGService rgService, ISubscritionService subscriptionService)
+        {
+            _rgService = rgService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public class Settings : CommandSettings
+        {
+            [CommandOption("-n|--name <NAME>")]
+            public string? Name { get; set; }
+
+            [CommandOption("-l|--location <LOCATION>")]
+            public string? Location { get; set; }
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+        {
+            if (string.IsNullOrEmpty(settings.Name) || string.IsNullOrEmpty(settings.Location))
+            {
+                AnsiConsole.MarkupLine("[red]You must specify --name and --location.[/]");
+                return 1;
+            }
+
+            var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+            var selectedSubscription = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Select a [green]subscription[/]:")
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                    .AddChoices(subscriptionChoices));
+
+            string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+            var result = await _rgService.CreateResourceGroupAsync(subscriptionId, settings.Name, settings.Location);
+            if (result)
+            {
+                AnsiConsole.MarkupLine($"[green]Resource group {settings.Name} created in {settings.Location}.[/]");
+                return 0;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+    }
+}

--- a/src/Commands/rg/RGDeleteSubscriptionCommand.cs
+++ b/src/Commands/rg/RGDeleteSubscriptionCommand.cs
@@ -1,0 +1,65 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.rg
+{
+    public class RGDeleteSubscriptionCommand : AsyncCommand<RGDeleteSubscriptionCommand.Settings>
+    {
+        private readonly IRGService _rgService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public RGDeleteSubscriptionCommand(IRGService rgService, ISubscritionService subscriptionService)
+        {
+            _rgService = rgService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public class Settings : CommandSettings
+        {
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+        {
+            var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+            var selectedSubscription = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Select a [green]subscription[/]:")
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                    .AddChoices(subscriptionChoices));
+
+            string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+            var rgs = await _rgService.FetchResourceGroupsBySubscriptionAsync(subscriptionId);
+            if (!rgs.Any())
+            {
+                AnsiConsole.MarkupLine("[red]No resource groups found.[/]");
+                return -1;
+            }
+
+            var rgName = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Select a [green]resource group[/] to delete:")
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more resource groups)[/]")
+                    .AddChoices(rgs.Select(r => r.ResourceGroup.Data.Name)));
+
+            if (!AnsiConsole.Confirm($"Are you sure you want to delete [yellow]{rgName}[/]?"))
+            {
+                AnsiConsole.MarkupLine("[yellow]Operation cancelled.[/]");
+                return 0;
+            }
+
+            var result = await _rgService.DeleteResourceGroupAsync(subscriptionId, rgName);
+            if (result)
+            {
+                AnsiConsole.MarkupLine($"[green]Deleted resource group {rgName}.[/]");
+                return 0;
+            }
+            else
+            {
+                return -1;
+            }
+        }
+    }
+}

--- a/src/Commands/rg/RGListAllCommand.cs
+++ b/src/Commands/rg/RGListAllCommand.cs
@@ -1,0 +1,65 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.rg
+{
+    public class RGListAllCommand : AsyncCommand<RGListAllCommand.Settings>
+    {
+        private readonly IRGService _rgService;
+
+        public RGListAllCommand(IRGService rgService)
+        {
+            _rgService = rgService;
+        }
+
+        public class Settings : CommandSettings
+        {
+            [CommandOption("-f|--filter <FILTER>")]
+            public string? Filter { get; set; }
+
+            [CommandOption("-e|--export <FILE_PATH>")]
+            public string? ExportPath { get; set; }
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+        {
+            var rgs = await _rgService.FetchAllResourceGroupsAsync(settings.Filter);
+            if (rgs.Any())
+            {
+                var grid = new Grid();
+                grid.AddColumn(new GridColumn().Width(35));
+                grid.AddColumn(new GridColumn().Width(20));
+                grid.AddColumn(new GridColumn().Width(30));
+                grid.AddRow("[bold darkgreen]Resource Group[/]", "[bold darkgreen]Location[/]", "[bold darkgreen]Subscription[/]");
+
+                foreach (var rg in rgs)
+                {
+                    grid.AddRow($"[blue]{rg.ResourceGroup.Data.Name}[/]", $"[yellow]{rg.ResourceGroup.Data.Location}[/]", $"[yellow]{rg.SubscriptionName}[/]");
+                }
+
+                AnsiConsole.Write(grid);
+
+                if (!string.IsNullOrEmpty(settings.ExportPath))
+                {
+                    try
+                    {
+                        var lines = new List<string> { "Name,Location,Subscription" };
+                        lines.AddRange(rgs.Select(r => $"{r.ResourceGroup.Data.Name},{r.ResourceGroup.Data.Location},{r.SubscriptionName}"));
+                        File.WriteAllLines(settings.ExportPath, lines);
+                        AnsiConsole.MarkupLine($"[green]Exported to {settings.ExportPath}[/]");
+                    }
+                    catch (Exception ex)
+                    {
+                        AnsiConsole.MarkupLine($"[red]Failed to export: {ex.Message}[/]");
+                    }
+                }
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[red]No resource groups found.[/]");
+            }
+            return 0;
+        }
+    }
+}

--- a/src/Commands/rg/RGListSubscriptionCommand.cs
+++ b/src/Commands/rg/RGListSubscriptionCommand.cs
@@ -1,0 +1,76 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.rg
+{
+    public class RGListSubscriptionCommand : AsyncCommand<RGListSubscriptionCommand.Settings>
+    {
+        private readonly IRGService _rgService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public RGListSubscriptionCommand(IRGService rgService, ISubscritionService subscriptionService)
+        {
+            _rgService = rgService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public class Settings : CommandSettings
+        {
+            [CommandOption("-f|--filter <FILTER>")]
+            public string? Filter { get; set; }
+
+            [CommandOption("-e|--export <FILE_PATH>")]
+            public string? ExportPath { get; set; }
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+        {
+            var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+            var selectedSubscription = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Select a [green]subscription[/]:")
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                    .AddChoices(subscriptionChoices));
+
+            string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+            var rgs = await _rgService.FetchResourceGroupsBySubscriptionAsync(subscriptionId, settings.Filter);
+            if (rgs.Any())
+            {
+                var grid = new Grid();
+                grid.AddColumn(new GridColumn().Width(35));
+                grid.AddColumn(new GridColumn().Width(20));
+                grid.AddColumn(new GridColumn().Width(30));
+                grid.AddRow("[bold darkgreen]Resource Group[/]", "[bold darkgreen]Location[/]", "[bold darkgreen]Subscription[/]");
+
+                foreach (var rg in rgs)
+                {
+                    grid.AddRow($"[blue]{rg.ResourceGroup.Data.Name}[/]", $"[yellow]{rg.ResourceGroup.Data.Location}[/]", $"[yellow]{rg.SubscriptionName}[/]");
+                }
+
+                AnsiConsole.Write(grid);
+
+                if (!string.IsNullOrEmpty(settings.ExportPath))
+                {
+                    try
+                    {
+                        var lines = new List<string> { "Name,Location,Subscription" };
+                        lines.AddRange(rgs.Select(r => $"{r.ResourceGroup.Data.Name},{r.ResourceGroup.Data.Location},{r.SubscriptionName}"));
+                        File.WriteAllLines(settings.ExportPath, lines);
+                        AnsiConsole.MarkupLine($"[green]Exported to {settings.ExportPath}[/]");
+                    }
+                    catch (Exception ex)
+                    {
+                        AnsiConsole.MarkupLine($"[red]Failed to export: {ex.Message}[/]");
+                    }
+                }
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[red]No resource groups found.[/]");
+            }
+            return 0;
+        }
+    }
+}

--- a/src/Commands/rg/RGShowSubscriptionCommand.cs
+++ b/src/Commands/rg/RGShowSubscriptionCommand.cs
@@ -1,0 +1,73 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.rg
+{
+    public class RGShowSubscriptionCommand : AsyncCommand<RGShowSubscriptionCommand.Settings>
+    {
+        private readonly IRGService _rgService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public RGShowSubscriptionCommand(IRGService rgService, ISubscritionService subscriptionService)
+        {
+            _rgService = rgService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public class Settings : CommandSettings
+        {
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+        {
+            var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+            var selectedSubscription = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Select a [green]subscription[/]:")
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                    .AddChoices(subscriptionChoices));
+
+            string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+            var rgs = await _rgService.FetchResourceGroupsBySubscriptionAsync(subscriptionId);
+            if (!rgs.Any())
+            {
+                AnsiConsole.MarkupLine("[red]No resource groups found.[/]");
+                return -1;
+            }
+
+            var rgName = AnsiConsole.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("Select a [green]resource group[/]:")
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more resource groups)[/]")
+                    .AddChoices(rgs.Select(r => r.ResourceGroup.Data.Name)));
+
+            var rg = await _rgService.GetResourceGroupAsync(subscriptionId, rgName);
+            if (rg != null)
+            {
+                var grid = new Grid();
+                grid.AddColumn(new GridColumn().NoWrap());
+                grid.AddColumn(new GridColumn().NoWrap());
+                grid.AddRow("[bold darkgreen]Name[/]", $"[blue]{rg.ResourceGroup.Data.Name}[/]");
+                grid.AddRow("[bold darkgreen]Location[/]", $"[yellow]{rg.ResourceGroup.Data.Location}[/]");
+                grid.AddRow("[bold darkgreen]Subscription[/]", $"[yellow]{rg.SubscriptionName}[/]");
+                if (rg.ResourceGroup.Data.Tags != null && rg.ResourceGroup.Data.Tags.Any())
+                {
+                    foreach (var tag in rg.ResourceGroup.Data.Tags)
+                    {
+                        grid.AddRow($"[bold darkgreen]Tag: {tag.Key}[/]", tag.Value);
+                    }
+                }
+                AnsiConsole.Write(grid);
+                return 0;
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[red]Resource group not found.[/]");
+                return -1;
+            }
+        }
+    }
+}

--- a/src/Interfaces/IRGService.cs
+++ b/src/Interfaces/IRGService.cs
@@ -1,0 +1,13 @@
+using AzureOpsCLI.Models;
+
+namespace AzureOpsCLI.Interfaces
+{
+    public interface IRGService
+    {
+        Task<List<ResourceGroupExtended>> FetchAllResourceGroupsAsync(string? filter = null);
+        Task<List<ResourceGroupExtended>> FetchResourceGroupsBySubscriptionAsync(string subscriptionId, string? filter = null);
+        Task<bool> CreateResourceGroupAsync(string subscriptionId, string resourceGroupName, string location);
+        Task<ResourceGroupExtended?> GetResourceGroupAsync(string subscriptionId, string resourceGroupName);
+        Task<bool> DeleteResourceGroupAsync(string subscriptionId, string resourceGroupName);
+    }
+}

--- a/src/Models/ResourceGroupExtended.cs
+++ b/src/Models/ResourceGroupExtended.cs
@@ -1,0 +1,10 @@
+using Azure.ResourceManager.Resources;
+
+namespace AzureOpsCLI.Models
+{
+    public class ResourceGroupExtended
+    {
+        public ResourceGroupResource ResourceGroup { get; set; }
+        public string SubscriptionName { get; set; }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -3,6 +3,7 @@ using AzureOpsCLI.Commands.apim;
 using AzureOpsCLI.Commands.imagegallery;
 using AzureOpsCLI.Commands.Info;
 using AzureOpsCLI.Commands.mg;
+using AzureOpsCLI.Commands.rg;
 using AzureOpsCLI.Commands.vm;
 using AzureOpsCLI.Commands.vmss;
 using AzureOpsCLI.Commands.vmss.instance;
@@ -26,11 +27,51 @@ class Program
         services.AddSingleton<IMGService, MGService>();
         services.AddSingleton<IAPIManagementService, APIManagementService>();
         services.AddSingleton<IStorageService, StorageService>();
+        services.AddSingleton<IRGService, RGService>();
         var registrar = new TypeRegistrar(services);
         var app = new CommandApp(registrar);
 
         app.Configure(config =>
         {
+            config.AddBranch("rg", rg =>
+            {
+                //Description
+                rg.SetDescription("Resource group commands");
+                rg.AddBranch("list", list =>
+                {
+                    //Description
+                    list.SetDescription("List commands associated with resource groups");
+                    //Commands
+                    list.AddCommand<RGListAllCommand>("all")
+                        .WithDescription("Get all resource groups in all subscriptions.");
+                    list.AddCommand<RGListSubscriptionCommand>("subscription")
+                        .WithDescription("Get all resource groups in a specific subscription.");
+                });
+                rg.AddBranch("create", create =>
+                {
+                    //Description
+                    create.SetDescription("Create commands associated with resource groups");
+                    //Commands
+                    create.AddCommand<RGCreateSubscriptionCommand>("subscription")
+                        .WithDescription("Create a resource group in a specific subscription.");
+                });
+                rg.AddBranch("show", show =>
+                {
+                    //Description
+                    show.SetDescription("Show commands associated with resource groups");
+                    //Commands
+                    show.AddCommand<RGShowSubscriptionCommand>("subscription")
+                        .WithDescription("Show details of a resource group in a specific subscription.");
+                });
+                rg.AddBranch("delete", delete =>
+                {
+                    //Description
+                    delete.SetDescription("Delete commands associated with resource groups");
+                    //Commands
+                    delete.AddCommand<RGDeleteSubscriptionCommand>("subscription")
+                        .WithDescription("Delete a resource group in a specific subscription.");
+                });
+            });
 
             config.AddBranch("vm", vm =>
             {

--- a/src/Services/RGService.cs
+++ b/src/Services/RGService.cs
@@ -1,0 +1,133 @@
+using Azure;
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.Resources.Models;
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Models;
+using Spectre.Console;
+
+namespace AzureOpsCLI.Services
+{
+    public class RGService : IRGService
+    {
+        private readonly ArmClient _armClient;
+
+        public RGService()
+        {
+            _armClient = new ArmClient(new DefaultAzureCredential());
+        }
+
+        public async Task<List<ResourceGroupExtended>> FetchAllResourceGroupsAsync(string? filter = null)
+        {
+            List<ResourceGroupExtended> rgs = new List<ResourceGroupExtended>();
+            try
+            {
+                await AnsiConsole.Status()
+                    .StartAsync("Fetching all subscriptions...", async ctx =>
+                    {
+                        await foreach (var subscription in _armClient.GetSubscriptions().GetAllAsync())
+                        {
+                            ctx.Status($"Fetching resource groups in {subscription.Data.DisplayName}...");
+                            await foreach (var rg in subscription.GetResourceGroups().GetAllAsync())
+                            {
+                                if (string.IsNullOrEmpty(filter) || rg.Data.Name.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    rgs.Add(new ResourceGroupExtended
+                                    {
+                                        ResourceGroup = rg,
+                                        SubscriptionName = subscription.Data.DisplayName
+                                    });
+                                }
+                            }
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error fetching resource groups: {ex.Message}[/]");
+            }
+            return rgs;
+        }
+
+        public async Task<List<ResourceGroupExtended>> FetchResourceGroupsBySubscriptionAsync(string subscriptionId, string? filter = null)
+        {
+            List<ResourceGroupExtended> rgs = new List<ResourceGroupExtended>();
+            try
+            {
+                SubscriptionResource subscription = await _armClient.GetSubscriptions().GetAsync(subscriptionId);
+                await AnsiConsole.Status()
+                    .StartAsync($"Fetching resource groups in subscription {subscription.Data.DisplayName}...", async ctx =>
+                    {
+                        await foreach (var rg in subscription.GetResourceGroups().GetAllAsync())
+                        {
+                            if (string.IsNullOrEmpty(filter) || rg.Data.Name.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                            {
+                                rgs.Add(new ResourceGroupExtended
+                                {
+                                    ResourceGroup = rg,
+                                    SubscriptionName = subscription.Data.DisplayName
+                                });
+                            }
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error fetching resource groups: {ex.Message}[/]");
+            }
+            return rgs;
+        }
+
+        public async Task<bool> CreateResourceGroupAsync(string subscriptionId, string resourceGroupName, string location)
+        {
+            try
+            {
+                SubscriptionResource subscription = await _armClient.GetSubscriptions().GetAsync(subscriptionId);
+                ResourceGroupData rgData = new ResourceGroupData(location);
+                await subscription.GetResourceGroups().CreateOrUpdateAsync(WaitUntil.Completed, resourceGroupName, rgData);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to create resource group: {ex.Message}[/]");
+                return false;
+            }
+        }
+
+        public async Task<ResourceGroupExtended?> GetResourceGroupAsync(string subscriptionId, string resourceGroupName)
+        {
+            try
+            {
+                SubscriptionResource subscription = await _armClient.GetSubscriptions().GetAsync(subscriptionId);
+                ResourceGroupResource rg = await subscription.GetResourceGroups().GetAsync(resourceGroupName);
+                return new ResourceGroupExtended
+                {
+                    ResourceGroup = rg,
+                    SubscriptionName = subscription.Data.DisplayName
+                };
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error fetching resource group: {ex.Message}[/]");
+                return null;
+            }
+        }
+
+        public async Task<bool> DeleteResourceGroupAsync(string subscriptionId, string resourceGroupName)
+        {
+            try
+            {
+                SubscriptionResource subscription = await _armClient.GetSubscriptions().GetAsync(subscriptionId);
+                ResourceGroupResource rg = await subscription.GetResourceGroups().GetAsync(resourceGroupName);
+                await rg.DeleteAsync(WaitUntil.Completed);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to delete resource group: {ex.Message}[/]");
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support listing resource groups across subscriptions with optional name filter and CSV export
- allow creating new resource groups in a selected subscription
- add commands to show details and delete resource groups within a subscription
