### PR TITLE
Add disk, lock, metrics commands and RG tags support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ packages
 
 # Windows
 Thumbs.db
+
+# Claude Code
+CLAUDE.md
+.claude/

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This is a hobby project and is maintained to the best of my ability, I am not a 
 The ambition with this project is to code for fun, but also to create something useful. :computer:  
 More functionality and improvements will be added over time.  
 
-At this point, this tool may not be the best option if you have a large number of subscriptions or resources, as the lists can become very long.  
-There are plans to add better filtering options, but we'll see if and when that happens.
+At this point, this tool may not be the best option if you have a large number of subscriptions or resources, as the lists can become very long.
+Many list commands now support `--filter` and `--export` options to help manage large result sets.
 
 There are probably tons of typos, ambiguities or other oddities, you are welcome to provide feedback so I can address them, thank you! :star:
 
@@ -27,13 +27,18 @@ There are probably tons of typos, ambiguities or other oddities, you are welcome
 
 - API Management:  `apim` -> `list | backup`
 - Azure Container Instances: `aci` ->  `list | start | stop | restart | delete | getlogs`
-- Azure Compute Gallery: `imagegallery` -> `list `
+- Azure Compute Gallery: `imagegallery` -> `list`
 - Azure Compute Gallery Images: `imagegallery images` -> `list`
+- Managed Disks: `disk` -> `list | list-unattached | snapshot | delete` (with filter and export support)
 - Management Group:  `mg` -> `show`
-- Resource Groups: `rg` -> `list | create` (filter and export supported)
-- Virtual Machines:  `vm` -> `list | start | stop | restart | delete`
+- Metrics: `metrics vm` -> `all | subscription` (CPU, memory, disk, network metrics)
+- Resource Groups: `rg` -> `list | create` (with filter, export, and --tags support)
+- Resource Locks: `lock` -> `list | apply | remove` (CanNotDelete or ReadOnly locks)
+- Resource Tags: `tags` -> `list | apply | remove | export`
+- Virtual Machines:  `vm` -> `list | start | stop | restart | delete` (with filter and export support)
 - Virtual Machines Scale Sets: `vmss` -> `list | start | stop | restart | delete | changeimage | reimage | upgrade`
 - Virtual Machines Scale Sets Instance:  `vmss instance` -> `list | start | stop | restart | reimage | upgrade`
+- Info: `info` -> Display information about the tool
 
 ## Installation
 
@@ -71,6 +76,51 @@ This command will fetch all subscriptions available and then list all accessible
 
 This command will fetch all subscriptions and present in a list, then list all accessible virtual machine scale sets from the selected subscription.
 
+### List VMs with filter and export to CSV
+>azo vm list all --filter prod --export csv
+
+This command will list all VMs containing "prod" in their name and export the results to a CSV file.
+
+### Show VM metrics across all subscriptions
+>azo metrics vm all
+
+This command will display CPU, memory, disk, and network metrics for all VMs across all subscriptions.
+
+### List all managed disks
+>azo disk list all
+
+This command will list all managed disks with their size, type, and attachment status.
+
+### List only unattached disks
+>azo disk list-unattached all
+
+This command will list only unattached (orphaned) managed disks across all subscriptions.
+
+### Create snapshots of selected disks
+>azo disk snapshot subscription
+
+This command will let you select disks from a subscription and create snapshots of them.
+
+### List resource locks
+>azo lock list all
+
+This command will list all resource locks (CanNotDelete or ReadOnly) across all subscriptions.
+
+### Apply a lock to resource groups
+>azo lock apply subscription
+
+This command will let you select resource groups and apply a CanNotDelete or ReadOnly lock to prevent accidental deletion.
+
+### Create a resource group with tags
+>azo rg create subscription --name my-rg --location westeurope --tags "env=prod;team=devops"
+
+This command will create a resource group with the specified tags applied.
+
+### Show tool information
+>azo info
+
+This command displays information about the Azure Ops CLI tool.
+
 ## Screenshots
 
 ### List all Virtual Machine Scale Sets in all subscriptions
@@ -85,6 +135,6 @@ This command will fetch all subscriptions and present in a list, then list all a
 ### Visualize Management Group Hierarchy.
 ![mg show](./resources/gfx/mg_show.gif)
 
-## Known Issues 
-- The console output of the `getlogs` command for Container Instances is messy and need some work.
-- Status messages can be messy when the resource names are of different lenght, might be some fix in Spectre Console, need some investigation.
+## Known Issues
+- The console output of the `getlogs` command for Container Instances is messy and needs some work.
+- Status messages can be messy when the resource names are of different length, might be some fix in Spectre Console, needs some investigation.

--- a/src/AzureOpsCLI.csproj
+++ b/src/AzureOpsCLI.csproj
@@ -9,8 +9,8 @@
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <Title>Azure Ops CLI</Title>
     <PackageProjectUrl>https://github.com/patkje75/AzureOpsCLI</PackageProjectUrl>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />

--- a/src/Commands/aci/ACIDeleteAllCommand.cs
+++ b/src/Commands/aci/ACIDeleteAllCommand.cs
@@ -28,7 +28,7 @@ namespace AzureOpsCLI.Commands.aci
 
             var selectedACIs = AnsiConsole.Prompt(
                 new MultiSelectionPrompt<string>()
-                    .Title("Select contaioner instance to delete:")
+                    .Title("Select container instance to delete:")
                     .NotRequired()
                     .PageSize(10)
                     .MoreChoicesText("[grey](Move up and down to reveal more container instances)[/]")
@@ -53,7 +53,7 @@ namespace AzureOpsCLI.Commands.aci
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Delete was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Delete was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/aci/ACIDeleteSubscriptionCommand.cs
+++ b/src/Commands/aci/ACIDeleteSubscriptionCommand.cs
@@ -65,7 +65,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Delete was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Delete was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/aci/ACIRestartAllCommand.cs
+++ b/src/Commands/aci/ACIRestartAllCommand.cs
@@ -28,7 +28,7 @@ namespace AzureOpsCLI.Commands.aci
 
             var selectedACIs = AnsiConsole.Prompt(
                 new MultiSelectionPrompt<string>()
-                    .Title("Select contaioner instance to restart:")
+                    .Title("Select container instance to restart:")
                     .NotRequired()
                     .PageSize(10)
                     .MoreChoicesText("[grey](Move up and down to reveal more container instances)[/]")
@@ -53,7 +53,7 @@ namespace AzureOpsCLI.Commands.aci
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Restart was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Restart was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/aci/ACIRestartSubscriptionCommand.cs
+++ b/src/Commands/aci/ACIRestartSubscriptionCommand.cs
@@ -65,7 +65,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Restart was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Restart was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/aci/ACIStartAllCommand.cs
+++ b/src/Commands/aci/ACIStartAllCommand.cs
@@ -28,7 +28,7 @@ namespace AzureOpsCLI.Commands.aci
 
             var selectedACIs = AnsiConsole.Prompt(
                 new MultiSelectionPrompt<string>()
-                    .Title("Select contaioner instance to start:")
+                    .Title("Select container instance to start:")
                     .NotRequired()
                     .PageSize(10)
                     .MoreChoicesText("[grey](Move up and down to reveal more container instances)[/]")
@@ -53,7 +53,7 @@ namespace AzureOpsCLI.Commands.aci
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Start was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Start was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/aci/ACIStartSubscriptionCommand.cs
+++ b/src/Commands/aci/ACIStartSubscriptionCommand.cs
@@ -65,7 +65,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Start was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Start was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/aci/ACIStopAllCommand.cs
+++ b/src/Commands/aci/ACIStopAllCommand.cs
@@ -28,7 +28,7 @@ namespace AzureOpsCLI.Commands.aci
 
             var selectedACIs = AnsiConsole.Prompt(
                 new MultiSelectionPrompt<string>()
-                    .Title("Select contaioner instance to stop:")
+                    .Title("Select container instance to stop:")
                     .NotRequired()
                     .PageSize(10)
                     .MoreChoicesText("[grey](Move up and down to reveal more container instances)[/]")
@@ -53,7 +53,7 @@ namespace AzureOpsCLI.Commands.aci
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Stop was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Stop was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/aci/ACIStopSubscriptionCommand.cs
+++ b/src/Commands/aci/ACIStopSubscriptionCommand.cs
@@ -65,7 +65,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Stop was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Stop was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/disk/DiskDeleteAllCommand.cs
+++ b/src/Commands/disk/DiskDeleteAllCommand.cs
@@ -1,0 +1,98 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.disk
+{
+    public class DiskDeleteAllCommand : AsyncCommand
+    {
+        private readonly IDiskService _diskService;
+
+        public DiskDeleteAllCommand(IDiskService diskService)
+        {
+            _diskService = diskService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context)
+        {
+            try
+            {
+                var disks = await AnsiConsole.Status()
+                    .StartAsync("Fetching unattached disks...", async ctx =>
+                    {
+                        return await _diskService.FetchUnattachedDisksAsync();
+                    });
+
+                if (!disks.Any())
+                {
+                    AnsiConsole.MarkupLine("[green]No unattached/orphaned disks found.[/]");
+                    return 0;
+                }
+
+                AnsiConsole.MarkupLine($"[yellow]Found {disks.Count} unattached disk(s)[/]");
+
+                var diskNames = disks.Select(d => $"{d.Disk.Data.Name} ({d.Disk.Data.DiskSizeGB} GB) - {d.SubscriptionName}").ToList();
+                var selectedDisks = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("Select unattached disk(s) to [red]delete[/]:")
+                        .NotRequired()
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more disks)[/]")
+                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle a disk, [green]<enter>[/] to delete)[/]")
+                        .AddChoices(diskNames));
+
+                if (!selectedDisks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No disks selected for deletion.[/]");
+                    return 0;
+                }
+
+                var confirmation = AnsiConsole.Confirm($"Are you sure you want to delete {selectedDisks.Count} disk(s)? [red]This action cannot be undone.[/]", false);
+                if (!confirmation)
+                {
+                    AnsiConsole.MarkupLine("[yellow]Operation cancelled.[/]");
+                    return 0;
+                }
+
+                await AnsiConsole.Progress()
+                    .Columns(new ProgressColumn[]
+                    {
+                        new TaskDescriptionColumn(),
+                        new SpinnerColumn(),
+                    })
+                    .StartAsync(async ctx =>
+                    {
+                        var tasks = selectedDisks.Select(diskName =>
+                        {
+                            var disk = disks.First(d => $"{d.Disk.Data.Name} ({d.Disk.Data.DiskSizeGB} GB) - {d.SubscriptionName}" == diskName);
+                            var task = ctx.AddTask($"Deleting {disk.Disk.Data.Name}");
+
+                            return _diskService.DeleteDiskAsync(disk.Disk)
+                                .ContinueWith(t =>
+                                {
+                                    if (t.Result.Success)
+                                    {
+                                        task.Description = $"Delete was [green]successful[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                    else
+                                    {
+                                        task.Description = $"[red]Failed[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                });
+                        }).ToList();
+
+                        await Task.WhenAll(tasks);
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to delete disks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/disk/DiskDeleteSubscriptionCommand.cs
+++ b/src/Commands/disk/DiskDeleteSubscriptionCommand.cs
@@ -1,0 +1,110 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.disk
+{
+    public class DiskDeleteSubscriptionCommand : AsyncCommand
+    {
+        private readonly IDiskService _diskService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public DiskDeleteSubscriptionCommand(IDiskService diskService, ISubscritionService subscriptionService)
+        {
+            _diskService = diskService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context)
+        {
+            try
+            {
+                var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+                var selectedSubscription = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select a [green]subscription[/]:")
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                        .AddChoices(subscriptionChoices));
+
+                string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+
+                var disks = await AnsiConsole.Status()
+                    .StartAsync("Fetching unattached disks...", async ctx =>
+                    {
+                        return await _diskService.FetchUnattachedDisksInSubscriptionAsync(subscriptionId);
+                    });
+
+                if (!disks.Any())
+                {
+                    AnsiConsole.MarkupLine("[green]No unattached/orphaned disks found in the selected subscription.[/]");
+                    return 0;
+                }
+
+                AnsiConsole.MarkupLine($"[yellow]Found {disks.Count} unattached disk(s)[/]");
+
+                var diskNames = disks.Select(d => $"{d.Disk.Data.Name} ({d.Disk.Data.DiskSizeGB} GB)").ToList();
+                var selectedDisks = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("Select unattached disk(s) to [red]delete[/]:")
+                        .NotRequired()
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more disks)[/]")
+                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle a disk, [green]<enter>[/] to delete)[/]")
+                        .AddChoices(diskNames));
+
+                if (!selectedDisks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No disks selected for deletion.[/]");
+                    return 0;
+                }
+
+                var confirmation = AnsiConsole.Confirm($"Are you sure you want to delete {selectedDisks.Count} disk(s)? [red]This action cannot be undone.[/]", false);
+                if (!confirmation)
+                {
+                    AnsiConsole.MarkupLine("[yellow]Operation cancelled.[/]");
+                    return 0;
+                }
+
+                await AnsiConsole.Progress()
+                    .Columns(new ProgressColumn[]
+                    {
+                        new TaskDescriptionColumn(),
+                        new SpinnerColumn(),
+                    })
+                    .StartAsync(async ctx =>
+                    {
+                        var tasks = selectedDisks.Select(diskName =>
+                        {
+                            var disk = disks.First(d => $"{d.Disk.Data.Name} ({d.Disk.Data.DiskSizeGB} GB)" == diskName);
+                            var task = ctx.AddTask($"Deleting {disk.Disk.Data.Name}");
+
+                            return _diskService.DeleteDiskAsync(disk.Disk)
+                                .ContinueWith(t =>
+                                {
+                                    if (t.Result.Success)
+                                    {
+                                        task.Description = $"Delete was [green]successful[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                    else
+                                    {
+                                        task.Description = $"[red]Failed[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                });
+                        }).ToList();
+
+                        await Task.WhenAll(tasks);
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to delete disks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/disk/DiskListAllCommand.cs
+++ b/src/Commands/disk/DiskListAllCommand.cs
@@ -1,0 +1,91 @@
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Settings;
+using AzureOpsCLI.Helpers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.disk
+{
+    public class DiskListAllCommand : AsyncCommand<ListCommandSettings>
+    {
+        private readonly IDiskService _diskService;
+
+        public DiskListAllCommand(IDiskService diskService)
+        {
+            _diskService = diskService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, ListCommandSettings settings)
+        {
+            try
+            {
+                var disks = await AnsiConsole.Status()
+                    .StartAsync("Fetching managed disks...", async ctx =>
+                    {
+                        return await _diskService.FetchAllDisksAsync();
+                    });
+
+                // Apply filter if specified
+                if (!string.IsNullOrEmpty(settings.Filter))
+                {
+                    disks = disks.Where(d => d.Disk.Data.Name.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                if (disks != null && disks.Any())
+                {
+                    var table = new Table();
+                    table.AddColumn(new TableColumn("[bold]Name[/]").Width(30));
+                    table.AddColumn(new TableColumn("[bold]Subscription[/]").Width(25));
+                    table.AddColumn(new TableColumn("[bold]Location[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Size (GB)[/]").Width(10));
+                    table.AddColumn(new TableColumn("[bold]Type[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Status[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Attached To[/]").Width(25));
+
+                    foreach (var disk in disks)
+                    {
+                        var statusColor = disk.IsAttached ? "green" : "yellow";
+                        var status = disk.IsAttached ? "Attached" : "Unattached";
+
+                        table.AddRow(
+                            $"[blue]{disk.Disk.Data.Name}[/]",
+                            disk.SubscriptionName,
+                            disk.Disk.Data.Location.ToString(),
+                            disk.Disk.Data.DiskSizeGB?.ToString() ?? "N/A",
+                            disk.Disk.Data.Sku?.Name?.ToString() ?? "N/A",
+                            $"[{statusColor}]{status}[/]",
+                            disk.AttachedTo
+                        );
+                    }
+
+                    AnsiConsole.Write(table);
+                    AnsiConsole.MarkupLine($"\nTotal: [blue]{disks.Count}[/] disks, [yellow]{disks.Count(d => !d.IsAttached)}[/] unattached");
+
+                    // Export if requested
+                    if (!string.IsNullOrEmpty(settings.ExportFormat))
+                    {
+                        await ExportHelper.ExportDataAsync(
+                            disks,
+                            settings.ExportFormat,
+                            "managed-disks-all",
+                            d => new[] { d.Disk.Data.Name, d.SubscriptionName, d.Disk.Data.Location.ToString(), d.Disk.Data.DiskSizeGB?.ToString() ?? "N/A", d.IsAttached ? "Attached" : "Unattached", d.AttachedTo },
+                            new[] { "Name", "Subscription", "Location", "SizeGB", "Status", "AttachedTo" },
+                            d => new { Name = d.Disk.Data.Name, Subscription = d.SubscriptionName, Location = d.Disk.Data.Location.ToString(), SizeGB = d.Disk.Data.DiskSizeGB, IsAttached = d.IsAttached, AttachedTo = d.AttachedTo }
+                        );
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[yellow]No managed disks found.[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to fetch disks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/disk/DiskListSubscriptionCommand.cs
+++ b/src/Commands/disk/DiskListSubscriptionCommand.cs
@@ -1,0 +1,101 @@
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Settings;
+using AzureOpsCLI.Helpers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.disk
+{
+    public class DiskListSubscriptionCommand : AsyncCommand<ListCommandSettings>
+    {
+        private readonly IDiskService _diskService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public DiskListSubscriptionCommand(IDiskService diskService, ISubscritionService subscriptionService)
+        {
+            _diskService = diskService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, ListCommandSettings settings)
+        {
+            try
+            {
+                var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+                var selectedSubscription = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select a [green]subscription[/]:")
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                        .AddChoices(subscriptionChoices));
+
+                string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+
+                var disks = await AnsiConsole.Status()
+                    .StartAsync("Fetching managed disks...", async ctx =>
+                    {
+                        return await _diskService.FetchDisksInSubscriptionAsync(subscriptionId);
+                    });
+
+                // Apply filter if specified
+                if (!string.IsNullOrEmpty(settings.Filter))
+                {
+                    disks = disks.Where(d => d.Disk.Data.Name.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                if (disks != null && disks.Any())
+                {
+                    var table = new Table();
+                    table.AddColumn(new TableColumn("[bold]Name[/]").Width(30));
+                    table.AddColumn(new TableColumn("[bold]Location[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Size (GB)[/]").Width(10));
+                    table.AddColumn(new TableColumn("[bold]Type[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Status[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Attached To[/]").Width(25));
+
+                    foreach (var disk in disks)
+                    {
+                        var statusColor = disk.IsAttached ? "green" : "yellow";
+                        var status = disk.IsAttached ? "Attached" : "Unattached";
+
+                        table.AddRow(
+                            $"[blue]{disk.Disk.Data.Name}[/]",
+                            disk.Disk.Data.Location.ToString(),
+                            disk.Disk.Data.DiskSizeGB?.ToString() ?? "N/A",
+                            disk.Disk.Data.Sku?.Name?.ToString() ?? "N/A",
+                            $"[{statusColor}]{status}[/]",
+                            disk.AttachedTo
+                        );
+                    }
+
+                    AnsiConsole.Write(table);
+                    AnsiConsole.MarkupLine($"\nTotal: [blue]{disks.Count}[/] disks, [yellow]{disks.Count(d => !d.IsAttached)}[/] unattached");
+
+                    // Export if requested
+                    if (!string.IsNullOrEmpty(settings.ExportFormat))
+                    {
+                        await ExportHelper.ExportDataAsync(
+                            disks,
+                            settings.ExportFormat,
+                            "managed-disks-subscription",
+                            d => new[] { d.Disk.Data.Name, d.Disk.Data.Location.ToString(), d.Disk.Data.DiskSizeGB?.ToString() ?? "N/A", d.IsAttached ? "Attached" : "Unattached", d.AttachedTo },
+                            new[] { "Name", "Location", "SizeGB", "Status", "AttachedTo" },
+                            d => new { Name = d.Disk.Data.Name, Location = d.Disk.Data.Location.ToString(), SizeGB = d.Disk.Data.DiskSizeGB, IsAttached = d.IsAttached, AttachedTo = d.AttachedTo }
+                        );
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[yellow]No managed disks found in the selected subscription.[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to fetch disks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/disk/DiskListUnattachedAllCommand.cs
+++ b/src/Commands/disk/DiskListUnattachedAllCommand.cs
@@ -1,0 +1,86 @@
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Settings;
+using AzureOpsCLI.Helpers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.disk
+{
+    public class DiskListUnattachedAllCommand : AsyncCommand<ListCommandSettings>
+    {
+        private readonly IDiskService _diskService;
+
+        public DiskListUnattachedAllCommand(IDiskService diskService)
+        {
+            _diskService = diskService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, ListCommandSettings settings)
+        {
+            try
+            {
+                var disks = await AnsiConsole.Status()
+                    .StartAsync("Fetching unattached managed disks...", async ctx =>
+                    {
+                        return await _diskService.FetchUnattachedDisksAsync();
+                    });
+
+                // Apply filter if specified
+                if (!string.IsNullOrEmpty(settings.Filter))
+                {
+                    disks = disks.Where(d => d.Disk.Data.Name.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                if (disks != null && disks.Any())
+                {
+                    var table = new Table();
+                    table.AddColumn(new TableColumn("[bold]Name[/]").Width(30));
+                    table.AddColumn(new TableColumn("[bold]Subscription[/]").Width(25));
+                    table.AddColumn(new TableColumn("[bold]Location[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Size (GB)[/]").Width(10));
+                    table.AddColumn(new TableColumn("[bold]Type[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Status[/]").Width(12));
+
+                    foreach (var disk in disks)
+                    {
+                        table.AddRow(
+                            $"[blue]{disk.Disk.Data.Name}[/]",
+                            disk.SubscriptionName,
+                            disk.Disk.Data.Location.ToString(),
+                            disk.Disk.Data.DiskSizeGB?.ToString() ?? "N/A",
+                            disk.Disk.Data.Sku?.Name?.ToString() ?? "N/A",
+                            "[yellow]Unattached[/]"
+                        );
+                    }
+
+                    AnsiConsole.Write(table);
+                    AnsiConsole.MarkupLine($"\nTotal: [yellow]{disks.Count}[/] unattached disks");
+
+                    // Export if requested
+                    if (!string.IsNullOrEmpty(settings.ExportFormat))
+                    {
+                        await ExportHelper.ExportDataAsync(
+                            disks,
+                            settings.ExportFormat,
+                            "unattached-disks-all",
+                            d => new[] { d.Disk.Data.Name, d.SubscriptionName, d.Disk.Data.Location.ToString(), d.Disk.Data.DiskSizeGB?.ToString() ?? "N/A", d.Disk.Data.Sku?.Name?.ToString() ?? "N/A" },
+                            new[] { "Name", "Subscription", "Location", "SizeGB", "Type" },
+                            d => new { Name = d.Disk.Data.Name, Subscription = d.SubscriptionName, Location = d.Disk.Data.Location.ToString(), SizeGB = d.Disk.Data.DiskSizeGB, Type = d.Disk.Data.Sku?.Name?.ToString() }
+                        );
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[green]No unattached managed disks found.[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to fetch unattached disks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/disk/DiskListUnattachedSubscriptionCommand.cs
+++ b/src/Commands/disk/DiskListUnattachedSubscriptionCommand.cs
@@ -1,0 +1,96 @@
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Settings;
+using AzureOpsCLI.Helpers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.disk
+{
+    public class DiskListUnattachedSubscriptionCommand : AsyncCommand<ListCommandSettings>
+    {
+        private readonly IDiskService _diskService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public DiskListUnattachedSubscriptionCommand(IDiskService diskService, ISubscritionService subscriptionService)
+        {
+            _diskService = diskService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, ListCommandSettings settings)
+        {
+            try
+            {
+                var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+                var selectedSubscription = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select a [green]subscription[/]:")
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                        .AddChoices(subscriptionChoices));
+
+                string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+
+                var disks = await AnsiConsole.Status()
+                    .StartAsync("Fetching unattached managed disks...", async ctx =>
+                    {
+                        return await _diskService.FetchUnattachedDisksInSubscriptionAsync(subscriptionId);
+                    });
+
+                // Apply filter if specified
+                if (!string.IsNullOrEmpty(settings.Filter))
+                {
+                    disks = disks.Where(d => d.Disk.Data.Name.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                if (disks != null && disks.Any())
+                {
+                    var table = new Table();
+                    table.AddColumn(new TableColumn("[bold]Name[/]").Width(30));
+                    table.AddColumn(new TableColumn("[bold]Location[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Size (GB)[/]").Width(10));
+                    table.AddColumn(new TableColumn("[bold]Type[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Status[/]").Width(12));
+
+                    foreach (var disk in disks)
+                    {
+                        table.AddRow(
+                            $"[blue]{disk.Disk.Data.Name}[/]",
+                            disk.Disk.Data.Location.ToString(),
+                            disk.Disk.Data.DiskSizeGB?.ToString() ?? "N/A",
+                            disk.Disk.Data.Sku?.Name?.ToString() ?? "N/A",
+                            "[yellow]Unattached[/]"
+                        );
+                    }
+
+                    AnsiConsole.Write(table);
+                    AnsiConsole.MarkupLine($"\nTotal: [yellow]{disks.Count}[/] unattached disks");
+
+                    // Export if requested
+                    if (!string.IsNullOrEmpty(settings.ExportFormat))
+                    {
+                        await ExportHelper.ExportDataAsync(
+                            disks,
+                            settings.ExportFormat,
+                            "unattached-disks-subscription",
+                            d => new[] { d.Disk.Data.Name, d.Disk.Data.Location.ToString(), d.Disk.Data.DiskSizeGB?.ToString() ?? "N/A", d.Disk.Data.Sku?.Name?.ToString() ?? "N/A" },
+                            new[] { "Name", "Location", "SizeGB", "Type" },
+                            d => new { Name = d.Disk.Data.Name, Location = d.Disk.Data.Location.ToString(), SizeGB = d.Disk.Data.DiskSizeGB, Type = d.Disk.Data.Sku?.Name?.ToString() }
+                        );
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[green]No unattached managed disks found in the selected subscription.[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to fetch unattached disks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/disk/DiskSnapshotAllCommand.cs
+++ b/src/Commands/disk/DiskSnapshotAllCommand.cs
@@ -1,0 +1,90 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.disk
+{
+    public class DiskSnapshotAllCommand : AsyncCommand
+    {
+        private readonly IDiskService _diskService;
+
+        public DiskSnapshotAllCommand(IDiskService diskService)
+        {
+            _diskService = diskService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context)
+        {
+            try
+            {
+                var disks = await AnsiConsole.Status()
+                    .StartAsync("Fetching managed disks...", async ctx =>
+                    {
+                        return await _diskService.FetchAllDisksAsync();
+                    });
+
+                if (!disks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No managed disks found.[/]");
+                    return 0;
+                }
+
+                var diskNames = disks.Select(d => $"{d.Disk.Data.Name} ({d.Disk.Data.DiskSizeGB} GB) - {d.SubscriptionName}").ToList();
+                var selectedDisks = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("Select disk(s) to create snapshots:")
+                        .NotRequired()
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more disks)[/]")
+                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle a disk, [green]<enter>[/] to create snapshots)[/]")
+                        .AddChoices(diskNames));
+
+                if (!selectedDisks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No disks selected for snapshot.[/]");
+                    return 0;
+                }
+
+                await AnsiConsole.Progress()
+                    .Columns(new ProgressColumn[]
+                    {
+                        new TaskDescriptionColumn(),
+                        new SpinnerColumn(),
+                    })
+                    .StartAsync(async ctx =>
+                    {
+                        var tasks = selectedDisks.Select(diskName =>
+                        {
+                            var disk = disks.First(d => $"{d.Disk.Data.Name} ({d.Disk.Data.DiskSizeGB} GB) - {d.SubscriptionName}" == diskName);
+                            var snapshotName = $"{disk.Disk.Data.Name}-snapshot-{DateTime.UtcNow:yyyyMMddHHmmss}";
+                            var task = ctx.AddTask($"Creating snapshot for {disk.Disk.Data.Name}");
+
+                            return _diskService.CreateSnapshotAsync(disk.Disk, snapshotName)
+                                .ContinueWith(t =>
+                                {
+                                    if (t.Result.Success)
+                                    {
+                                        task.Description = $"Snapshot was [green]successful[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                    else
+                                    {
+                                        task.Description = $"[red]Failed[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                });
+                        }).ToList();
+
+                        await Task.WhenAll(tasks);
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to create snapshots: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/disk/DiskSnapshotSubscriptionCommand.cs
+++ b/src/Commands/disk/DiskSnapshotSubscriptionCommand.cs
@@ -1,0 +1,102 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.disk
+{
+    public class DiskSnapshotSubscriptionCommand : AsyncCommand
+    {
+        private readonly IDiskService _diskService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public DiskSnapshotSubscriptionCommand(IDiskService diskService, ISubscritionService subscriptionService)
+        {
+            _diskService = diskService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context)
+        {
+            try
+            {
+                var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+                var selectedSubscription = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select a [green]subscription[/]:")
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                        .AddChoices(subscriptionChoices));
+
+                string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+
+                var disks = await AnsiConsole.Status()
+                    .StartAsync("Fetching managed disks...", async ctx =>
+                    {
+                        return await _diskService.FetchDisksInSubscriptionAsync(subscriptionId);
+                    });
+
+                if (!disks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No managed disks found in the selected subscription.[/]");
+                    return 0;
+                }
+
+                var diskNames = disks.Select(d => $"{d.Disk.Data.Name} ({d.Disk.Data.DiskSizeGB} GB)").ToList();
+                var selectedDisks = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("Select disk(s) to create snapshots:")
+                        .NotRequired()
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more disks)[/]")
+                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle a disk, [green]<enter>[/] to create snapshots)[/]")
+                        .AddChoices(diskNames));
+
+                if (!selectedDisks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No disks selected for snapshot.[/]");
+                    return 0;
+                }
+
+                await AnsiConsole.Progress()
+                    .Columns(new ProgressColumn[]
+                    {
+                        new TaskDescriptionColumn(),
+                        new SpinnerColumn(),
+                    })
+                    .StartAsync(async ctx =>
+                    {
+                        var tasks = selectedDisks.Select(diskName =>
+                        {
+                            var disk = disks.First(d => $"{d.Disk.Data.Name} ({d.Disk.Data.DiskSizeGB} GB)" == diskName);
+                            var snapshotName = $"{disk.Disk.Data.Name}-snapshot-{DateTime.UtcNow:yyyyMMddHHmmss}";
+                            var task = ctx.AddTask($"Creating snapshot for {disk.Disk.Data.Name}");
+
+                            return _diskService.CreateSnapshotAsync(disk.Disk, snapshotName)
+                                .ContinueWith(t =>
+                                {
+                                    if (t.Result.Success)
+                                    {
+                                        task.Description = $"Snapshot was [green]successful[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                    else
+                                    {
+                                        task.Description = $"[red]Failed[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                });
+                        }).ToList();
+
+                        await Task.WhenAll(tasks);
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to create snapshots: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/info/InfoCommand.cs
+++ b/src/Commands/info/InfoCommand.cs
@@ -36,9 +36,25 @@ namespace AzureOpsCLI.Commands.Info
             var imageGalleryImages = imageGallery.AddNode("[blue]images[/]");
             imageGalleryImages.AddNode("[green]list[/] [lightseagreen]all | subscription[/]");
 
+            var disk = root.AddNode("[blue]disk[/]");
+            disk.AddNode("[green]delete[/] [lightseagreen]all | subscription[/]");
+            disk.AddNode("[green]list[/] [lightseagreen]all | subscription[/] ([purple4]--filter --export[/])");
+            disk.AddNode("[green]list-unattached[/] [lightseagreen]all | subscription[/] ([purple4]--filter --export[/])");
+            disk.AddNode("[green]snapshot[/] [lightseagreen]all | subscription[/]");
+
+            var lockCmd = root.AddNode("[blue]lock[/]");
+            lockCmd.AddNode("[green]apply[/] [lightseagreen]all | subscription[/]");
+            lockCmd.AddNode("[green]list[/] [lightseagreen]all | subscription[/]");
+            lockCmd.AddNode("[green]remove[/] [lightseagreen]all | subscription[/]");
+
+            var metrics = root.AddNode("[blue]metrics[/]");
+            var metricsVm = metrics.AddNode("[blue]vm[/]");
+            metricsVm.AddNode("[green]all[/]");
+            metricsVm.AddNode("[green]subscription[/]");
+
             var rg = root.AddNode("[blue]rg[/]");
-            rg.AddNode("[green]create[/] [lightseagreen]subscription[/] ([purple4]--name --location[/])");
-            rg.AddNode("[green]list[/] [lightseagreen]all | subscription[/]");
+            rg.AddNode("[green]create[/] [lightseagreen]subscription[/] ([purple4]--name --location --tags[/])");
+            rg.AddNode("[green]list[/] [lightseagreen]all | subscription[/] ([purple4]--filter --export[/])");
 
             var tags = root.AddNode("[blue]tags[/]");
             tags.AddNode("[green]apply[/] [lightseagreen]all | subscription[/]");
@@ -46,9 +62,9 @@ namespace AzureOpsCLI.Commands.Info
             tags.AddNode("[green]list[/] [lightseagreen]all | subscription[/]");
             tags.AddNode("[green]remove[/] [lightseagreen]all | subscription[/]");
 
-            var vm = root.AddNode("[blue]vm[/] [lightseagreen]all | subscription[/]");
+            var vm = root.AddNode("[blue]vm[/]");
             vm.AddNode("[green]delete[/] [lightseagreen]all | subscription[/]");
-            vm.AddNode("[green]list[/] [lightseagreen]all | subscription[/]");
+            vm.AddNode("[green]list[/] [lightseagreen]all | subscription[/] ([purple4]--filter --export[/])");
             vm.AddNode("[green]restart[/] [lightseagreen]all | subscription[/]");
             vm.AddNode("[green]start[/] [lightseagreen]all | subscription[/]");
             vm.AddNode("[green]stop[/] [lightseagreen]all | subscription[/]");

--- a/src/Commands/lock/LockApplyAllCommand.cs
+++ b/src/Commands/lock/LockApplyAllCommand.cs
@@ -1,0 +1,98 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.resourcelock
+{
+    public class LockApplyAllCommand : AsyncCommand
+    {
+        private readonly ILockService _lockService;
+
+        public LockApplyAllCommand(ILockService lockService)
+        {
+            _lockService = lockService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context)
+        {
+            try
+            {
+                var resources = await AnsiConsole.Status()
+                    .StartAsync("Fetching resource groups...", async ctx =>
+                    {
+                        return await _lockService.FetchLockableResourcesAsync();
+                    });
+
+                // Filter to show only unlocked resources
+                var unlockedResources = resources.Where(r => !r.HasLock).ToList();
+
+                if (!unlockedResources.Any())
+                {
+                    AnsiConsole.MarkupLine("[green]All resource groups already have locks applied.[/]");
+                    return 0;
+                }
+
+                var resourceNames = unlockedResources.Select(r => $"{r.Name} ({r.Type}) - {r.SubscriptionName}").ToList();
+                var selectedResources = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("Select resource group(s) to apply lock:")
+                        .NotRequired()
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more resources)[/]")
+                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle, [green]<enter>[/] to apply locks)[/]")
+                        .AddChoices(resourceNames));
+
+                if (!selectedResources.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No resources selected.[/]");
+                    return 0;
+                }
+
+                var lockLevel = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select lock level:")
+                        .AddChoices(new[] { "CanNotDelete", "ReadOnly" }));
+
+                await AnsiConsole.Progress()
+                    .Columns(new ProgressColumn[]
+                    {
+                        new TaskDescriptionColumn(),
+                        new SpinnerColumn(),
+                    })
+                    .StartAsync(async ctx =>
+                    {
+                        var tasks = selectedResources.Select(resourceName =>
+                        {
+                            var resource = unlockedResources.First(r => $"{r.Name} ({r.Type}) - {r.SubscriptionName}" == resourceName);
+                            var lockName = $"lock-{resource.Name}-{DateTime.UtcNow:yyyyMMddHHmmss}";
+                            var task = ctx.AddTask($"Applying lock to {resource.Name}");
+
+                            return _lockService.ApplyLockAsync(resource.ResourceId, lockName, lockLevel)
+                                .ContinueWith(t =>
+                                {
+                                    if (t.Result.Success)
+                                    {
+                                        task.Description = $"Lock was [green]successful[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                    else
+                                    {
+                                        task.Description = $"[red]Failed[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                });
+                        }).ToList();
+
+                        await Task.WhenAll(tasks);
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to apply locks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/lock/LockApplySubscriptionCommand.cs
+++ b/src/Commands/lock/LockApplySubscriptionCommand.cs
@@ -1,0 +1,110 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.resourcelock
+{
+    public class LockApplySubscriptionCommand : AsyncCommand
+    {
+        private readonly ILockService _lockService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public LockApplySubscriptionCommand(ILockService lockService, ISubscritionService subscriptionService)
+        {
+            _lockService = lockService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context)
+        {
+            try
+            {
+                var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+                var selectedSubscription = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select a [green]subscription[/]:")
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                        .AddChoices(subscriptionChoices));
+
+                string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+
+                var resources = await AnsiConsole.Status()
+                    .StartAsync("Fetching resource groups...", async ctx =>
+                    {
+                        return await _lockService.FetchLockableResourcesInSubscriptionAsync(subscriptionId);
+                    });
+
+                // Filter to show only unlocked resources
+                var unlockedResources = resources.Where(r => !r.HasLock).ToList();
+
+                if (!unlockedResources.Any())
+                {
+                    AnsiConsole.MarkupLine("[green]All resource groups in this subscription already have locks applied.[/]");
+                    return 0;
+                }
+
+                var resourceNames = unlockedResources.Select(r => $"{r.Name} ({r.Type})").ToList();
+                var selectedResources = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("Select resource group(s) to apply lock:")
+                        .NotRequired()
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more resources)[/]")
+                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle, [green]<enter>[/] to apply locks)[/]")
+                        .AddChoices(resourceNames));
+
+                if (!selectedResources.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No resources selected.[/]");
+                    return 0;
+                }
+
+                var lockLevel = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select lock level:")
+                        .AddChoices(new[] { "CanNotDelete", "ReadOnly" }));
+
+                await AnsiConsole.Progress()
+                    .Columns(new ProgressColumn[]
+                    {
+                        new TaskDescriptionColumn(),
+                        new SpinnerColumn(),
+                    })
+                    .StartAsync(async ctx =>
+                    {
+                        var tasks = selectedResources.Select(resourceName =>
+                        {
+                            var resource = unlockedResources.First(r => $"{r.Name} ({r.Type})" == resourceName);
+                            var lockName = $"lock-{resource.Name}-{DateTime.UtcNow:yyyyMMddHHmmss}";
+                            var task = ctx.AddTask($"Applying lock to {resource.Name}");
+
+                            return _lockService.ApplyLockAsync(resource.ResourceId, lockName, lockLevel)
+                                .ContinueWith(t =>
+                                {
+                                    if (t.Result.Success)
+                                    {
+                                        task.Description = $"Lock was [green]successful[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                    else
+                                    {
+                                        task.Description = $"[red]Failed[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                });
+                        }).ToList();
+
+                        await Task.WhenAll(tasks);
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to apply locks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/lock/LockListAllCommand.cs
+++ b/src/Commands/lock/LockListAllCommand.cs
@@ -1,0 +1,86 @@
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Settings;
+using AzureOpsCLI.Helpers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.resourcelock
+{
+    public class LockListAllCommand : AsyncCommand<ListCommandSettings>
+    {
+        private readonly ILockService _lockService;
+
+        public LockListAllCommand(ILockService lockService)
+        {
+            _lockService = lockService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, ListCommandSettings settings)
+        {
+            try
+            {
+                var locks = await AnsiConsole.Status()
+                    .StartAsync("Fetching resource locks...", async ctx =>
+                    {
+                        return await _lockService.FetchAllLocksAsync();
+                    });
+
+                // Apply filter if specified
+                if (!string.IsNullOrEmpty(settings.Filter))
+                {
+                    locks = locks.Where(l => l.Lock.Data.Name.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase) ||
+                                             l.ResourceName.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                if (locks != null && locks.Any())
+                {
+                    var table = new Table();
+                    table.AddColumn(new TableColumn("[bold]Lock Name[/]").Width(25));
+                    table.AddColumn(new TableColumn("[bold]Level[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Resource[/]").Width(30));
+                    table.AddColumn(new TableColumn("[bold]Type[/]").Width(20));
+                    table.AddColumn(new TableColumn("[bold]Subscription[/]").Width(25));
+
+                    foreach (var lockItem in locks)
+                    {
+                        var levelColor = lockItem.Lock.Data.Level == Azure.ResourceManager.Resources.Models.ManagementLockLevel.ReadOnly ? "red" : "yellow";
+                        table.AddRow(
+                            $"[blue]{lockItem.Lock.Data.Name}[/]",
+                            $"[{levelColor}]{lockItem.Lock.Data.Level}[/]",
+                            lockItem.ResourceName,
+                            lockItem.ResourceType,
+                            lockItem.SubscriptionName
+                        );
+                    }
+
+                    AnsiConsole.Write(table);
+                    AnsiConsole.MarkupLine($"\nTotal: [blue]{locks.Count}[/] lock(s)");
+
+                    // Export if requested
+                    if (!string.IsNullOrEmpty(settings.ExportFormat))
+                    {
+                        await ExportHelper.ExportDataAsync(
+                            locks,
+                            settings.ExportFormat,
+                            "resource-locks-all",
+                            l => new[] { l.Lock.Data.Name, l.Lock.Data.Level.ToString(), l.ResourceName, l.ResourceType, l.SubscriptionName },
+                            new[] { "LockName", "Level", "Resource", "Type", "Subscription" },
+                            l => new { LockName = l.Lock.Data.Name, Level = l.Lock.Data.Level.ToString(), Resource = l.ResourceName, Type = l.ResourceType, Subscription = l.SubscriptionName }
+                        );
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[yellow]No resource locks found.[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to fetch locks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/lock/LockListSubscriptionCommand.cs
+++ b/src/Commands/lock/LockListSubscriptionCommand.cs
@@ -1,0 +1,96 @@
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Settings;
+using AzureOpsCLI.Helpers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.resourcelock
+{
+    public class LockListSubscriptionCommand : AsyncCommand<ListCommandSettings>
+    {
+        private readonly ILockService _lockService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public LockListSubscriptionCommand(ILockService lockService, ISubscritionService subscriptionService)
+        {
+            _lockService = lockService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, ListCommandSettings settings)
+        {
+            try
+            {
+                var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+                var selectedSubscription = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select a [green]subscription[/]:")
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                        .AddChoices(subscriptionChoices));
+
+                string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+
+                var locks = await AnsiConsole.Status()
+                    .StartAsync("Fetching resource locks...", async ctx =>
+                    {
+                        return await _lockService.FetchLocksInSubscriptionAsync(subscriptionId);
+                    });
+
+                // Apply filter if specified
+                if (!string.IsNullOrEmpty(settings.Filter))
+                {
+                    locks = locks.Where(l => l.Lock.Data.Name.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase) ||
+                                             l.ResourceName.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                if (locks != null && locks.Any())
+                {
+                    var table = new Table();
+                    table.AddColumn(new TableColumn("[bold]Lock Name[/]").Width(25));
+                    table.AddColumn(new TableColumn("[bold]Level[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]Resource[/]").Width(30));
+                    table.AddColumn(new TableColumn("[bold]Type[/]").Width(20));
+
+                    foreach (var lockItem in locks)
+                    {
+                        var levelColor = lockItem.Lock.Data.Level == Azure.ResourceManager.Resources.Models.ManagementLockLevel.ReadOnly ? "red" : "yellow";
+                        table.AddRow(
+                            $"[blue]{lockItem.Lock.Data.Name}[/]",
+                            $"[{levelColor}]{lockItem.Lock.Data.Level}[/]",
+                            lockItem.ResourceName,
+                            lockItem.ResourceType
+                        );
+                    }
+
+                    AnsiConsole.Write(table);
+                    AnsiConsole.MarkupLine($"\nTotal: [blue]{locks.Count}[/] lock(s)");
+
+                    // Export if requested
+                    if (!string.IsNullOrEmpty(settings.ExportFormat))
+                    {
+                        await ExportHelper.ExportDataAsync(
+                            locks,
+                            settings.ExportFormat,
+                            "resource-locks-subscription",
+                            l => new[] { l.Lock.Data.Name, l.Lock.Data.Level.ToString(), l.ResourceName, l.ResourceType },
+                            new[] { "LockName", "Level", "Resource", "Type" },
+                            l => new { LockName = l.Lock.Data.Name, Level = l.Lock.Data.Level.ToString(), Resource = l.ResourceName, Type = l.ResourceType }
+                        );
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[yellow]No resource locks found in the selected subscription.[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to fetch locks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/lock/LockRemoveAllCommand.cs
+++ b/src/Commands/lock/LockRemoveAllCommand.cs
@@ -1,0 +1,96 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.resourcelock
+{
+    public class LockRemoveAllCommand : AsyncCommand
+    {
+        private readonly ILockService _lockService;
+
+        public LockRemoveAllCommand(ILockService lockService)
+        {
+            _lockService = lockService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context)
+        {
+            try
+            {
+                var locks = await AnsiConsole.Status()
+                    .StartAsync("Fetching resource locks...", async ctx =>
+                    {
+                        return await _lockService.FetchAllLocksAsync();
+                    });
+
+                if (!locks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No resource locks found.[/]");
+                    return 0;
+                }
+
+                var lockNames = locks.Select(l => $"{l.Lock.Data.Name} ({l.Lock.Data.Level}) on {l.ResourceName} - {l.SubscriptionName}").ToList();
+                var selectedLocks = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("Select lock(s) to [red]remove[/]:")
+                        .NotRequired()
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more locks)[/]")
+                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle, [green]<enter>[/] to remove)[/]")
+                        .AddChoices(lockNames));
+
+                if (!selectedLocks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No locks selected for removal.[/]");
+                    return 0;
+                }
+
+                var confirmation = AnsiConsole.Confirm($"Are you sure you want to remove {selectedLocks.Count} lock(s)?", false);
+                if (!confirmation)
+                {
+                    AnsiConsole.MarkupLine("[yellow]Operation cancelled.[/]");
+                    return 0;
+                }
+
+                await AnsiConsole.Progress()
+                    .Columns(new ProgressColumn[]
+                    {
+                        new TaskDescriptionColumn(),
+                        new SpinnerColumn(),
+                    })
+                    .StartAsync(async ctx =>
+                    {
+                        var tasks = selectedLocks.Select(lockName =>
+                        {
+                            var lockItem = locks.First(l => $"{l.Lock.Data.Name} ({l.Lock.Data.Level}) on {l.ResourceName} - {l.SubscriptionName}" == lockName);
+                            var task = ctx.AddTask($"Removing lock {lockItem.Lock.Data.Name}");
+
+                            return _lockService.RemoveLockAsync(lockItem.Lock)
+                                .ContinueWith(t =>
+                                {
+                                    if (t.Result.Success)
+                                    {
+                                        task.Description = $"Remove was [green]successful[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                    else
+                                    {
+                                        task.Description = $"[red]Failed[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                });
+                        }).ToList();
+
+                        await Task.WhenAll(tasks);
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to remove locks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/lock/LockRemoveSubscriptionCommand.cs
+++ b/src/Commands/lock/LockRemoveSubscriptionCommand.cs
@@ -1,0 +1,108 @@
+using AzureOpsCLI.Interfaces;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.resourcelock
+{
+    public class LockRemoveSubscriptionCommand : AsyncCommand
+    {
+        private readonly ILockService _lockService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public LockRemoveSubscriptionCommand(ILockService lockService, ISubscritionService subscriptionService)
+        {
+            _lockService = lockService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context)
+        {
+            try
+            {
+                var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+                var selectedSubscription = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select a [green]subscription[/]:")
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                        .AddChoices(subscriptionChoices));
+
+                string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+
+                var locks = await AnsiConsole.Status()
+                    .StartAsync("Fetching resource locks...", async ctx =>
+                    {
+                        return await _lockService.FetchLocksInSubscriptionAsync(subscriptionId);
+                    });
+
+                if (!locks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No resource locks found in the selected subscription.[/]");
+                    return 0;
+                }
+
+                var lockNames = locks.Select(l => $"{l.Lock.Data.Name} ({l.Lock.Data.Level}) on {l.ResourceName}").ToList();
+                var selectedLocks = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("Select lock(s) to [red]remove[/]:")
+                        .NotRequired()
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more locks)[/]")
+                        .InstructionsText("[grey](Press [blue]<space>[/] to toggle, [green]<enter>[/] to remove)[/]")
+                        .AddChoices(lockNames));
+
+                if (!selectedLocks.Any())
+                {
+                    AnsiConsole.MarkupLine("[yellow]No locks selected for removal.[/]");
+                    return 0;
+                }
+
+                var confirmation = AnsiConsole.Confirm($"Are you sure you want to remove {selectedLocks.Count} lock(s)?", false);
+                if (!confirmation)
+                {
+                    AnsiConsole.MarkupLine("[yellow]Operation cancelled.[/]");
+                    return 0;
+                }
+
+                await AnsiConsole.Progress()
+                    .Columns(new ProgressColumn[]
+                    {
+                        new TaskDescriptionColumn(),
+                        new SpinnerColumn(),
+                    })
+                    .StartAsync(async ctx =>
+                    {
+                        var tasks = selectedLocks.Select(lockName =>
+                        {
+                            var lockItem = locks.First(l => $"{l.Lock.Data.Name} ({l.Lock.Data.Level}) on {l.ResourceName}" == lockName);
+                            var task = ctx.AddTask($"Removing lock {lockItem.Lock.Data.Name}");
+
+                            return _lockService.RemoveLockAsync(lockItem.Lock)
+                                .ContinueWith(t =>
+                                {
+                                    if (t.Result.Success)
+                                    {
+                                        task.Description = $"Remove was [green]successful[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                    else
+                                    {
+                                        task.Description = $"[red]Failed[/]: {t.Result.Message}";
+                                        task.Increment(100);
+                                    }
+                                });
+                        }).ToList();
+
+                        await Task.WhenAll(tasks);
+                    });
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to remove locks: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/src/Commands/metrics/MetricsVMAllCommand.cs
+++ b/src/Commands/metrics/MetricsVMAllCommand.cs
@@ -1,0 +1,111 @@
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Settings;
+using AzureOpsCLI.Helpers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.metrics
+{
+    public class MetricsVMAllCommand : AsyncCommand<ListCommandSettings>
+    {
+        private readonly IMetricsService _metricsService;
+
+        public MetricsVMAllCommand(IMetricsService metricsService)
+        {
+            _metricsService = metricsService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, ListCommandSettings settings)
+        {
+            try
+            {
+                var metrics = await AnsiConsole.Status()
+                    .StartAsync("Fetching VM metrics...", async ctx =>
+                    {
+                        return await _metricsService.FetchAllVMMetricsAsync();
+                    });
+
+                // Apply filter if specified
+                if (!string.IsNullOrEmpty(settings.Filter))
+                {
+                    metrics = metrics.Where(m => m.Name.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                if (metrics != null && metrics.Any())
+                {
+                    var table = new Table();
+                    table.AddColumn(new TableColumn("[bold]Name[/]").Width(25));
+                    table.AddColumn(new TableColumn("[bold]Subscription[/]").Width(20));
+                    table.AddColumn(new TableColumn("[bold]Location[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]CPU %[/]").Width(10));
+                    table.AddColumn(new TableColumn("[bold]Memory[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Disk R[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Disk W[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Net In[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Net Out[/]").Width(12));
+
+                    foreach (var m in metrics)
+                    {
+                        var cpuColor = GetCpuColor(m.CpuPercentage);
+                        table.AddRow(
+                            $"[blue]{m.Name}[/]",
+                            m.SubscriptionName,
+                            m.Location,
+                            $"[{cpuColor}]{FormatDouble(m.CpuPercentage)}[/]",
+                            FormatBytes(m.MemoryPercentage),
+                            FormatBytes(m.DiskReadBytesPerSec),
+                            FormatBytes(m.DiskWriteBytesPerSec),
+                            FormatBytes(m.NetworkInBytesPerSec),
+                            FormatBytes(m.NetworkOutBytesPerSec)
+                        );
+                    }
+
+                    AnsiConsole.Write(table);
+
+                    // Export if requested
+                    if (!string.IsNullOrEmpty(settings.ExportFormat))
+                    {
+                        await ExportHelper.ExportDataAsync(
+                            metrics,
+                            settings.ExportFormat,
+                            "vm-metrics-all",
+                            m => new[] { m.Name, m.SubscriptionName, m.Location, FormatDouble(m.CpuPercentage), FormatBytes(m.MemoryPercentage), FormatBytes(m.DiskReadBytesPerSec) },
+                            new[] { "Name", "Subscription", "Location", "CPU%", "Memory", "DiskRead" },
+                            m => new { m.Name, m.SubscriptionName, m.Location, m.CpuPercentage, m.MemoryPercentage, m.DiskReadBytesPerSec, m.DiskWriteBytesPerSec }
+                        );
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[yellow]No VM metrics found.[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to fetch metrics: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+
+        private static string FormatDouble(double? value) => value.HasValue ? $"{value:F1}" : "N/A";
+
+        private static string FormatBytes(double? bytes)
+        {
+            if (!bytes.HasValue) return "N/A";
+            var kb = bytes.Value / 1024;
+            if (kb < 1024) return $"{kb:F1} KB";
+            var mb = kb / 1024;
+            return $"{mb:F1} MB";
+        }
+
+        private static string GetCpuColor(double? cpu)
+        {
+            if (!cpu.HasValue) return "grey";
+            if (cpu < 50) return "green";
+            if (cpu < 80) return "yellow";
+            return "red";
+        }
+    }
+}

--- a/src/Commands/metrics/MetricsVMSubscriptionCommand.cs
+++ b/src/Commands/metrics/MetricsVMSubscriptionCommand.cs
@@ -1,0 +1,121 @@
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Settings;
+using AzureOpsCLI.Helpers;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Commands.metrics
+{
+    public class MetricsVMSubscriptionCommand : AsyncCommand<ListCommandSettings>
+    {
+        private readonly IMetricsService _metricsService;
+        private readonly ISubscritionService _subscriptionService;
+
+        public MetricsVMSubscriptionCommand(IMetricsService metricsService, ISubscritionService subscriptionService)
+        {
+            _metricsService = metricsService;
+            _subscriptionService = subscriptionService;
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, ListCommandSettings settings)
+        {
+            try
+            {
+                var subscriptionChoices = await _subscriptionService.FetchSubscriptionsAsync();
+                var selectedSubscription = AnsiConsole.Prompt(
+                    new SelectionPrompt<string>()
+                        .Title("Select a [green]subscription[/]:")
+                        .PageSize(10)
+                        .MoreChoicesText("[grey](Move up and down to reveal more subscriptions)[/]")
+                        .AddChoices(subscriptionChoices));
+
+                string subscriptionId = selectedSubscription.Split('(').Last().TrimEnd(')');
+
+                var metrics = await AnsiConsole.Status()
+                    .StartAsync("Fetching VM metrics...", async ctx =>
+                    {
+                        return await _metricsService.FetchVMMetricsInSubscriptionAsync(subscriptionId);
+                    });
+
+                // Apply filter if specified
+                if (!string.IsNullOrEmpty(settings.Filter))
+                {
+                    metrics = metrics.Where(m => m.Name.Contains(settings.Filter, StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                if (metrics != null && metrics.Any())
+                {
+                    var table = new Table();
+                    table.AddColumn(new TableColumn("[bold]Name[/]").Width(25));
+                    table.AddColumn(new TableColumn("[bold]Location[/]").Width(15));
+                    table.AddColumn(new TableColumn("[bold]CPU %[/]").Width(10));
+                    table.AddColumn(new TableColumn("[bold]Memory[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Disk R[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Disk W[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Net In[/]").Width(12));
+                    table.AddColumn(new TableColumn("[bold]Net Out[/]").Width(12));
+
+                    foreach (var m in metrics)
+                    {
+                        var cpuColor = GetCpuColor(m.CpuPercentage);
+                        table.AddRow(
+                            $"[blue]{m.Name}[/]",
+                            m.Location,
+                            $"[{cpuColor}]{FormatDouble(m.CpuPercentage)}[/]",
+                            FormatBytes(m.MemoryPercentage),
+                            FormatBytes(m.DiskReadBytesPerSec),
+                            FormatBytes(m.DiskWriteBytesPerSec),
+                            FormatBytes(m.NetworkInBytesPerSec),
+                            FormatBytes(m.NetworkOutBytesPerSec)
+                        );
+                    }
+
+                    AnsiConsole.Write(table);
+
+                    // Export if requested
+                    if (!string.IsNullOrEmpty(settings.ExportFormat))
+                    {
+                        await ExportHelper.ExportDataAsync(
+                            metrics,
+                            settings.ExportFormat,
+                            "vm-metrics-subscription",
+                            m => new[] { m.Name, m.Location, FormatDouble(m.CpuPercentage), FormatBytes(m.MemoryPercentage) },
+                            new[] { "Name", "Location", "CPU%", "Memory" },
+                            m => new { m.Name, m.Location, m.CpuPercentage, m.MemoryPercentage, m.DiskReadBytesPerSec, m.DiskWriteBytesPerSec }
+                        );
+                    }
+                }
+                else
+                {
+                    AnsiConsole.MarkupLine("[yellow]No VM metrics found in the selected subscription.[/]");
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to fetch metrics: {ex.Message}[/]");
+                return -1;
+            }
+
+            return 0;
+        }
+
+        private static string FormatDouble(double? value) => value.HasValue ? $"{value:F1}" : "N/A";
+
+        private static string FormatBytes(double? bytes)
+        {
+            if (!bytes.HasValue) return "N/A";
+            var kb = bytes.Value / 1024;
+            if (kb < 1024) return $"{kb:F1} KB";
+            var mb = kb / 1024;
+            return $"{mb:F1} MB";
+        }
+
+        private static string GetCpuColor(double? cpu)
+        {
+            if (!cpu.HasValue) return "grey";
+            if (cpu < 50) return "green";
+            if (cpu < 80) return "yellow";
+            return "red";
+        }
+    }
+}

--- a/src/Commands/vm/VMDeleteAllCommand.cs
+++ b/src/Commands/vm/VMDeleteAllCommand.cs
@@ -53,7 +53,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Delete was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Delete was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vm/VMDeleteSubscriptionCommand.cs
+++ b/src/Commands/vm/VMDeleteSubscriptionCommand.cs
@@ -65,7 +65,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Delete was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Delete was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vm/VMRestartAllCommand.cs
+++ b/src/Commands/vm/VMRestartAllCommand.cs
@@ -53,7 +53,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Restart was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Restart was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vm/VMRestartSubscriptionCommand.cs
+++ b/src/Commands/vm/VMRestartSubscriptionCommand.cs
@@ -65,7 +65,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Restart was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Restart was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vm/VMStartAllCommand.cs
+++ b/src/Commands/vm/VMStartAllCommand.cs
@@ -53,7 +53,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Start was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Start was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vm/VMStartSubscriptionCommand.cs
+++ b/src/Commands/vm/VMStartSubscriptionCommand.cs
@@ -65,7 +65,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Start was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Start was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vm/VMStopAllCommand.cs
+++ b/src/Commands/vm/VMStopAllCommand.cs
@@ -53,7 +53,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Stop was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Stop was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vm/VMStopSubscriptionCommand.cs
+++ b/src/Commands/vm/VMStopSubscriptionCommand.cs
@@ -65,7 +65,7 @@ namespace AzureOpsCLI.Commands.vm
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Stop was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Stop was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSDeleteAllCommand.cs
+++ b/src/Commands/vmss/VMSSDeleteAllCommand.cs
@@ -69,7 +69,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Delete was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Delete was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSDeleteSubscriptionCommand.cs
+++ b/src/Commands/vmss/VMSSDeleteSubscriptionCommand.cs
@@ -83,7 +83,7 @@ public class VMSSDeleteSubscriptionCommand : AsyncCommand
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Delete was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Delete was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSReimageAllCommand.cs
+++ b/src/Commands/vmss/VMSSReimageAllCommand.cs
@@ -52,7 +52,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Reimage was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Reimage was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSReimageSubscriptionCommand.cs
+++ b/src/Commands/vmss/VMSSReimageSubscriptionCommand.cs
@@ -64,7 +64,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Reimage was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Reimage was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSRestartAllCommand.cs
+++ b/src/Commands/vmss/VMSSRestartAllCommand.cs
@@ -52,7 +52,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Restart was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Restart was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSRestartSubscriptionCommand.cs
+++ b/src/Commands/vmss/VMSSRestartSubscriptionCommand.cs
@@ -64,7 +64,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Restart was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Restart was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSStartAllCommand.cs
+++ b/src/Commands/vmss/VMSSStartAllCommand.cs
@@ -52,7 +52,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Start was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Start was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSStartSubscriptionCommand.cs
+++ b/src/Commands/vmss/VMSSStartSubscriptionCommand.cs
@@ -64,7 +64,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Start was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Start was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSStopAllCommand.cs
+++ b/src/Commands/vmss/VMSSStopAllCommand.cs
@@ -52,7 +52,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Stop was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Stop was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSStopSubscriptionCommand.cs
+++ b/src/Commands/vmss/VMSSStopSubscriptionCommand.cs
@@ -63,7 +63,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Stop was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Stop was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSUpgradeAllCommand.cs
+++ b/src/Commands/vmss/VMSSUpgradeAllCommand.cs
@@ -50,7 +50,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Upgrade was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Upgrade was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/VMSSUpgradeSubscriptionCommand.cs
+++ b/src/Commands/vmss/VMSSUpgradeSubscriptionCommand.cs
@@ -65,7 +65,7 @@ public class VMSSUpgradeSubscriptionCommand : AsyncCommand
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Upgrade was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Upgrade was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceListSubscriptionCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceListSubscriptionCommand.cs
@@ -2,16 +2,16 @@
 using Spectre.Console;
 using Spectre.Console.Cli;
 
-namespace AzureOpsCLI.Commands.vmss
+namespace AzureOpsCLI.Commands.vmss.instance
 {
-    public class VMSSListScriptionCommand : AsyncCommand
+    public class VMSSInstanceListSubscriptionCommand : AsyncCommand
     {
-        private readonly IVMSSService _vmssService;
+        private readonly IVMSSVMService _vmssvmService;
         private readonly ISubscritionService _subscriptionService;
 
-        public VMSSListScriptionCommand(IVMSSService vmssService, ISubscritionService subscritionService)
+        public VMSSInstanceListSubscriptionCommand(IVMSSVMService vmssvmService, ISubscritionService subscritionService)
         {
-            _vmssService = vmssService;
+            _vmssvmService = vmssvmService;
             _subscriptionService = subscritionService;
         }
 
@@ -30,34 +30,36 @@ namespace AzureOpsCLI.Commands.vmss
 
             try
             {
-                var vmscalesets = await _vmssService.FetchVMSSInSubscriptionAsync(subscriptionId);
+                var vmscalesets = await _vmssvmService.FetchVMSSInstancesInSubscriptionAsync(subscriptionId);
                 if (vmscalesets.Count > 0)
                 {
                     var grid = new Grid();
-
+                    grid.AddColumn(new GridColumn().Width(30));
                     grid.AddColumn(new GridColumn().Width(30));
                     grid.AddColumn(new GridColumn().Width(15));
                     grid.AddColumn(new GridColumn().Width(30));
+                    grid.AddColumn(new GridColumn().Width(15));
                     grid.AddColumn(new GridColumn().Width(10));
-                    grid.AddColumn(new GridColumn().Width(20));
                     grid.AddColumn(new GridColumn().Width(30));
                     grid.AddColumn(new GridColumn().Width(25));
                     grid.AddColumn(new GridColumn().Width(17));
 
                     grid.AddRow(
-                        "[bold darkgreen]Name[/]",
+                        "[bold darkgreen]Instance Name[/]",
+                        "[bold darkgreen]Scale Set[/]",
                         "[bold darkgreen]Location[/]",
-                        "[bold darkgreen]Subscription Name[/]",
+                        "[bold darkgreen]Subscription[/]",
+                        "[bold darkgreen]Latest Model[/]",
                         "[bold darkgreen]Status[/]",
-                        "[bold darkgreen]Instances[/]",
                         "[bold darkgreen]Image Name[/]",
-                        "[bold darkgreen]Version[/]",
+                        "[bold darkgreen]Image Version[/]",
                         "[bold darkgreen]Marketplace Image[/]"
-                        );
+                    );
 
-                    foreach (var vmss in vmscalesets)
+                    foreach (var vmssvms in vmscalesets)
                     {
-                        var imageReference = vmss.VMSS.Data.VirtualMachineProfile?.StorageProfile?.ImageReference;
+
+                        var imageReference = vmssvms.VMSS.Data.VirtualMachineProfile?.StorageProfile?.ImageReference;
                         string imageReferenceId = imageReference?.Id;
                         string imageName = "No image name found";
                         string imageVersion = "No version specified";
@@ -75,7 +77,6 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 imageName = parts[10];
                             }
-
                         }
                         else
                         {
@@ -84,15 +85,17 @@ namespace AzureOpsCLI.Commands.vmss
                             marketplace = true;
                         }
 
-                        var statusColor = vmss.Status != "running" ? "red" : "green";
+                        var latestModelColor = vmssvms.VMSSVm.Data.LatestModelApplied == true ? "green" : "red";
+                        var statusColor = vmssvms.Status == "running" ? "green" : "red";
                         var marketplaceColor = marketplace != true ? "red" : "green";
 
                         grid.AddRow(
-                            $"[blue]{vmss.VMSS.Data.Name}[/]",
-                            $"[yellow]{vmss.VMSS.Data.Location}[/]",
-                            $"[yellow]{vmss.SubscriptionName}[/]",
-                            $"[{statusColor}]{vmss.Status}[/]",
-                            $"[yellow]{vmss.numberOfInstances}[/]",
+                            $"[blue]{vmssvms.VMSSVm.Data.Name}[/]",
+                            $"[yellow]{vmssvms.VMSS.Data.Name}[/]",
+                            $"[yellow]{vmssvms.VMSSVm.Data.Location}[/]",
+                            $"[yellow]{vmssvms.SubscriptionName}[/]",
+                            $"[{latestModelColor}]{vmssvms.VMSSVm.Data.LatestModelApplied}[/]",
+                            $"[{statusColor}]{vmssvms.Status}[/]",
                             $"[yellow]{imageName}[/]",
                             $"[yellow]{imageVersion}[/]",
                             $"[{marketplaceColor}]{marketplace}[/]"
@@ -103,7 +106,7 @@ namespace AzureOpsCLI.Commands.vmss
                 }
                 else
                 {
-                    AnsiConsole.MarkupLine("[red]No virtual machine scale sets found.[/]");
+                    AnsiConsole.MarkupLine("[red]No virtual machine scale set instances found.[/]");
                 }
             }
             catch (Exception ex)

--- a/src/Commands/vmss/instance/VMSSInstanceReimageAllCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceReimageAllCommand.cs
@@ -52,7 +52,7 @@ namespace AzureOpsCLI.Commands.vmss.instance
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Reimage was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Reimage was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceReimageSubscriptionCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceReimageSubscriptionCommand.cs
@@ -66,7 +66,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Reimage was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Reimage was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceRestartAllCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceRestartAllCommand.cs
@@ -52,7 +52,7 @@ namespace AzureOpsCLI.Commands.vmss.instance
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Restart was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Restart was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceRestartSubscriptionCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceRestartSubscriptionCommand.cs
@@ -65,7 +65,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Restart was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Restart was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceStartAllCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceStartAllCommand.cs
@@ -52,7 +52,7 @@ namespace AzureOpsCLI.Commands.vmss.instance
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Start was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Start was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceStartSubscriptionCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceStartSubscriptionCommand.cs
@@ -64,7 +64,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Start was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Start was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceStopAllCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceStopAllCommand.cs
@@ -58,7 +58,7 @@ namespace AzureOpsCLI.Commands.vmss.instance
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Stop was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Stop was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceStopSubscriptionCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceStopSubscriptionCommand.cs
@@ -66,7 +66,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Stop was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Stop was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceUpgradeAllCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceUpgradeAllCommand.cs
@@ -50,7 +50,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Upgrade was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Upgrade was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Commands/vmss/instance/VMSSInstanceUpgradeSubscriptionCommand.cs
+++ b/src/Commands/vmss/instance/VMSSInstanceUpgradeSubscriptionCommand.cs
@@ -63,7 +63,7 @@ namespace AzureOpsCLI.Commands.vmss
                             {
                                 if (t.Result.Success)
                                 {
-                                    task.Description = $"Upgrade was [green]successfull[/]: {t.Result.Message}";
+                                    task.Description = $"Upgrade was [green]successful[/]: {t.Result.Message}";
                                     task.Increment(100);
                                 }
                                 else

--- a/src/Helpers/ExportHelper.cs
+++ b/src/Helpers/ExportHelper.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using Spectre.Console;
+
+namespace AzureOpsCLI.Helpers
+{
+    public static class ExportHelper
+    {
+        public static async Task ExportToCsvAsync<T>(IEnumerable<T> data, string filename, Func<T, string[]> rowSelector, string[] headers)
+        {
+            var lines = new List<string> { string.Join(",", headers) };
+            lines.AddRange(data.Select(item => string.Join(",", rowSelector(item).Select(EscapeCsvField))));
+            await File.WriteAllLinesAsync(filename, lines);
+        }
+
+        public static async Task ExportToJsonAsync<T>(IEnumerable<T> data, string filename, Func<T, object> objectSelector)
+        {
+            var objects = data.Select(objectSelector).ToList();
+            var json = JsonSerializer.Serialize(objects, new JsonSerializerOptions { WriteIndented = true });
+            await File.WriteAllTextAsync(filename, json);
+        }
+
+        public static async Task<bool> ExportDataAsync<T>(
+            IEnumerable<T> data,
+            string? exportFormat,
+            string resourceType,
+            Func<T, string[]> csvRowSelector,
+            string[] csvHeaders,
+            Func<T, object> jsonObjectSelector)
+        {
+            if (string.IsNullOrEmpty(exportFormat))
+                return false;
+
+            var format = exportFormat.ToLower();
+            if (format != "csv" && format != "json")
+            {
+                AnsiConsole.MarkupLine($"[red]Invalid export format '{exportFormat}'. Use 'csv' or 'json'.[/]");
+                return false;
+            }
+
+            var timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
+            var filename = $"{resourceType}_{timestamp}.{format}";
+
+            try
+            {
+                if (format == "csv")
+                {
+                    await ExportToCsvAsync(data, filename, csvRowSelector, csvHeaders);
+                }
+                else
+                {
+                    await ExportToJsonAsync(data, filename, jsonObjectSelector);
+                }
+
+                AnsiConsole.MarkupLine($"[green]Exported to {filename}[/]");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Failed to export: {ex.Message}[/]");
+                return false;
+            }
+        }
+
+        private static string EscapeCsvField(string field)
+        {
+            if (string.IsNullOrEmpty(field))
+                return field;
+
+            if (field.Contains(',') || field.Contains('"') || field.Contains('\n'))
+            {
+                return $"\"{field.Replace("\"", "\"\"")}\"";
+            }
+            return field;
+        }
+    }
+}

--- a/src/Interfaces/IDiskService.cs
+++ b/src/Interfaces/IDiskService.cs
@@ -1,0 +1,34 @@
+using AzureOpsCLI.Models;
+using Azure.ResourceManager.Compute;
+
+namespace AzureOpsCLI.Interfaces
+{
+    public interface IDiskService
+    {
+        Task<List<ManagedDiskExtended>> FetchAllDisksAsync();
+        Task<List<ManagedDiskExtended>> FetchDisksInSubscriptionAsync(string subscriptionId);
+        Task<List<ManagedDiskExtended>> FetchUnattachedDisksAsync();
+        Task<List<ManagedDiskExtended>> FetchUnattachedDisksInSubscriptionAsync(string subscriptionId);
+        Task<OperationResult> CreateSnapshotAsync(ManagedDiskResource disk, string snapshotName);
+        Task<OperationResult> DeleteDiskAsync(ManagedDiskResource disk);
+    }
+
+    public class ManagedDiskExtended
+    {
+        public ManagedDiskResource Disk { get; set; } = null!;
+        public string SubscriptionName { get; set; } = string.Empty;
+        public string SubscriptionId { get; set; } = string.Empty;
+        public bool IsAttached => Disk.Data.ManagedBy != null;
+        public string AttachedTo => GetAttachedVmName();
+
+        private string GetAttachedVmName()
+        {
+            if (Disk.Data.ManagedBy == null)
+                return "Unattached";
+
+            var managedByString = Disk.Data.ManagedBy.ToString();
+            var parts = managedByString.Split('/');
+            return parts.Length > 0 ? parts[^1] : "Unknown";
+        }
+    }
+}

--- a/src/Interfaces/ILockService.cs
+++ b/src/Interfaces/ILockService.cs
@@ -1,0 +1,35 @@
+using Azure.ResourceManager.Resources;
+using AzureOpsCLI.Models;
+
+namespace AzureOpsCLI.Interfaces
+{
+    public interface ILockService
+    {
+        Task<List<ResourceLockExtended>> FetchAllLocksAsync();
+        Task<List<ResourceLockExtended>> FetchLocksInSubscriptionAsync(string subscriptionId);
+        Task<List<LockableResource>> FetchLockableResourcesAsync();
+        Task<List<LockableResource>> FetchLockableResourcesInSubscriptionAsync(string subscriptionId);
+        Task<OperationResult> ApplyLockAsync(string resourceId, string lockName, string lockLevel);
+        Task<OperationResult> RemoveLockAsync(ManagementLockResource lockResource);
+    }
+
+    public class ResourceLockExtended
+    {
+        public ManagementLockResource Lock { get; set; } = null!;
+        public string SubscriptionName { get; set; } = string.Empty;
+        public string ResourceName { get; set; } = string.Empty;
+        public string ResourceType { get; set; } = string.Empty;
+    }
+
+    public class LockableResource
+    {
+        public string ResourceId { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public string SubscriptionName { get; set; } = string.Empty;
+        public string SubscriptionId { get; set; } = string.Empty;
+        public string ResourceGroup { get; set; } = string.Empty;
+        public bool HasLock { get; set; }
+        public string? ExistingLockLevel { get; set; }
+    }
+}

--- a/src/Interfaces/IMetricsService.cs
+++ b/src/Interfaces/IMetricsService.cs
@@ -1,0 +1,37 @@
+using AzureOpsCLI.Models;
+
+namespace AzureOpsCLI.Interfaces
+{
+    public interface IMetricsService
+    {
+        Task<List<VmMetrics>> FetchAllVMMetricsAsync();
+        Task<List<VmMetrics>> FetchVMMetricsInSubscriptionAsync(string subscriptionId);
+        Task<List<VmssMetrics>> FetchAllVMSSMetricsAsync();
+        Task<List<VmssMetrics>> FetchVMSSMetricsInSubscriptionAsync(string subscriptionId);
+    }
+
+    public class VmMetrics
+    {
+        public string Name { get; set; } = string.Empty;
+        public string SubscriptionName { get; set; } = string.Empty;
+        public string ResourceGroup { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public double? CpuPercentage { get; set; }
+        public double? MemoryPercentage { get; set; }
+        public double? DiskReadBytesPerSec { get; set; }
+        public double? DiskWriteBytesPerSec { get; set; }
+        public double? NetworkInBytesPerSec { get; set; }
+        public double? NetworkOutBytesPerSec { get; set; }
+    }
+
+    public class VmssMetrics
+    {
+        public string Name { get; set; } = string.Empty;
+        public string SubscriptionName { get; set; } = string.Empty;
+        public string ResourceGroup { get; set; } = string.Empty;
+        public string Location { get; set; } = string.Empty;
+        public int InstanceCount { get; set; }
+        public double? AvgCpuPercentage { get; set; }
+        public double? AvgMemoryPercentage { get; set; }
+    }
+}

--- a/src/Interfaces/IRGService.cs
+++ b/src/Interfaces/IRGService.cs
@@ -6,6 +6,6 @@ namespace AzureOpsCLI.Interfaces
     {
         Task<List<ResourceGroupExtended>> FetchAllResourceGroupsAsync(string? filter = null);
         Task<List<ResourceGroupExtended>> FetchResourceGroupsBySubscriptionAsync(string subscriptionId, string? filter = null);
-        Task<bool> CreateResourceGroupAsync(string subscriptionId, string resourceGroupName, string location);
+        Task<bool> CreateResourceGroupAsync(string subscriptionId, string resourceGroupName, string location, Dictionary<string, string>? tags = null);
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,7 +1,10 @@
 ﻿using AzureOpsCLI.Commands.aci;
 using AzureOpsCLI.Commands.apim;
+using AzureOpsCLI.Commands.disk;
 using AzureOpsCLI.Commands.imagegallery;
 using AzureOpsCLI.Commands.Info;
+using AzureOpsCLI.Commands.resourcelock;
+using AzureOpsCLI.Commands.metrics;
 using AzureOpsCLI.Commands.mg;
 using AzureOpsCLI.Commands.rg;
 using AzureOpsCLI.Commands.vm;
@@ -30,6 +33,9 @@ class Program
         services.AddSingleton<IStorageService, StorageService>();
         services.AddSingleton<IRGService, RGService>();
         services.AddSingleton<ITagService, TagService>();
+        services.AddSingleton<IMetricsService, MetricsService>();
+        services.AddSingleton<IDiskService, DiskService>();
+        services.AddSingleton<ILockService, LockService>();
         var registrar = new TypeRegistrar(services);
         var app = new CommandApp(registrar);
 
@@ -131,7 +137,7 @@ class Program
                     //Commands
                     list.AddCommand<VMSSListAllCommand>("all")
                         .WithDescription("Get all virtual machine scale sets in all subscriptions.");
-                    list.AddCommand<VMSSListScriptionCommand>("subscription")
+                    list.AddCommand<VMSSListSubscriptionCommand>("subscription")
                         .WithDescription("Get all virtual machine scale sets in a specific subscriptions.");
                 });
                 vmss.AddBranch("start", start =>
@@ -220,7 +226,7 @@ class Program
                         //Commands
                         list.AddCommand<VMSSInstanceListAllCommand>("all")
                             .WithDescription("Get all virtual machine scale set instances in all subscriptions.");
-                        list.AddCommand<VMSSInstanceListScriptionCommand>("subscription")
+                        list.AddCommand<VMSSInstanceListSubscriptionCommand>("subscription")
                         .WithDescription("Get all virtual machine scale set instances in a specific subscriptions.");
 
                     });
@@ -384,7 +390,7 @@ class Program
             config.AddBranch("apim", apim =>
             {
                 //Description
-                apim.SetDescription("API Mangagenment Service commands");
+                apim.SetDescription("API Management Service commands");
                 apim.AddBranch("list", list =>
                 {
                     //Description
@@ -460,6 +466,85 @@ class Program
                         .WithDescription("Export resource tag information from all subscriptions to JSON or CSV.");
                     export.AddCommand<TagExportSubscriptionCommand>("subscription")
                         .WithDescription("Export resource tag information from a specific subscription to JSON or CSV.");
+                });
+            });
+
+            config.AddBranch("metrics", metrics =>
+            {
+                metrics.SetDescription("Azure Monitor metrics commands");
+                metrics.AddBranch("vm", vm =>
+                {
+                    vm.SetDescription("VM metrics commands");
+                    vm.AddCommand<MetricsVMAllCommand>("all")
+                        .WithDescription("Show CPU/memory metrics for VMs across all subscriptions.");
+                    vm.AddCommand<MetricsVMSubscriptionCommand>("subscription")
+                        .WithDescription("Show CPU/memory metrics for VMs in a specific subscription.");
+                });
+            });
+
+            config.AddBranch("disk", disk =>
+            {
+                disk.SetDescription("Managed disk commands");
+                disk.AddBranch("list", list =>
+                {
+                    list.SetDescription("List managed disks");
+                    list.AddCommand<DiskListAllCommand>("all")
+                        .WithDescription("List all managed disks across all subscriptions.");
+                    list.AddCommand<DiskListSubscriptionCommand>("subscription")
+                        .WithDescription("List all managed disks in a specific subscription.");
+                });
+                disk.AddBranch("list-unattached", listUnattached =>
+                {
+                    listUnattached.SetDescription("List only unattached managed disks");
+                    listUnattached.AddCommand<DiskListUnattachedAllCommand>("all")
+                        .WithDescription("List unattached managed disks across all subscriptions.");
+                    listUnattached.AddCommand<DiskListUnattachedSubscriptionCommand>("subscription")
+                        .WithDescription("List unattached managed disks in a specific subscription.");
+                });
+                disk.AddBranch("snapshot", snapshot =>
+                {
+                    snapshot.SetDescription("Create disk snapshots");
+                    snapshot.AddCommand<DiskSnapshotAllCommand>("all")
+                        .WithDescription("Create snapshots of selected disks across all subscriptions.");
+                    snapshot.AddCommand<DiskSnapshotSubscriptionCommand>("subscription")
+                        .WithDescription("Create snapshots of selected disks in a specific subscription.");
+                });
+                disk.AddBranch("delete", delete =>
+                {
+                    delete.SetDescription("Delete unattached/orphaned disks");
+                    delete.AddCommand<DiskDeleteAllCommand>("all")
+                        .WithDescription("Delete selected unattached disks across all subscriptions.");
+                    delete.AddCommand<DiskDeleteSubscriptionCommand>("subscription")
+                        .WithDescription("Delete selected unattached disks in a specific subscription.");
+                });
+            });
+
+            config.AddBranch("lock", lockBranch =>
+            {
+                lockBranch.SetDescription("Resource lock commands for governance");
+                lockBranch.AddBranch("list", list =>
+                {
+                    list.SetDescription("List resource locks");
+                    list.AddCommand<LockListAllCommand>("all")
+                        .WithDescription("List all resource locks across all subscriptions.");
+                    list.AddCommand<LockListSubscriptionCommand>("subscription")
+                        .WithDescription("List all resource locks in a specific subscription.");
+                });
+                lockBranch.AddBranch("apply", apply =>
+                {
+                    apply.SetDescription("Apply locks to resources");
+                    apply.AddCommand<LockApplyAllCommand>("all")
+                        .WithDescription("Apply CanNotDelete or ReadOnly lock to selected resources across all subscriptions.");
+                    apply.AddCommand<LockApplySubscriptionCommand>("subscription")
+                        .WithDescription("Apply CanNotDelete or ReadOnly lock to selected resources in a specific subscription.");
+                });
+                lockBranch.AddBranch("remove", remove =>
+                {
+                    remove.SetDescription("Remove locks from resources");
+                    remove.AddCommand<LockRemoveAllCommand>("all")
+                        .WithDescription("Remove locks from selected resources across all subscriptions.");
+                    remove.AddCommand<LockRemoveSubscriptionCommand>("subscription")
+                        .WithDescription("Remove locks from selected resources in a specific subscription.");
                 });
             });
 

--- a/src/Services/DiskService.cs
+++ b/src/Services/DiskService.cs
@@ -1,0 +1,137 @@
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Compute;
+using Azure.ResourceManager.Compute.Models;
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Models;
+
+namespace AzureOpsCLI.Services
+{
+    public class DiskService : IDiskService
+    {
+        private readonly ArmClient _armClient;
+
+        public DiskService()
+        {
+            _armClient = new ArmClient(new DefaultAzureCredential());
+        }
+
+        public async Task<List<ManagedDiskExtended>> FetchAllDisksAsync()
+        {
+            var disks = new List<ManagedDiskExtended>();
+
+            await foreach (var subscription in _armClient.GetSubscriptions())
+            {
+                var diskCollection = subscription.GetManagedDisksAsync();
+                await foreach (var disk in diskCollection)
+                {
+                    disks.Add(new ManagedDiskExtended
+                    {
+                        Disk = disk,
+                        SubscriptionName = subscription.Data.DisplayName,
+                        SubscriptionId = subscription.Data.SubscriptionId
+                    });
+                }
+            }
+
+            return disks;
+        }
+
+        public async Task<List<ManagedDiskExtended>> FetchDisksInSubscriptionAsync(string subscriptionId)
+        {
+            var disks = new List<ManagedDiskExtended>();
+            var subscription = _armClient.GetSubscriptionResource(new Azure.Core.ResourceIdentifier($"/subscriptions/{subscriptionId}"));
+
+            var diskCollection = subscription.GetManagedDisksAsync();
+            await foreach (var disk in diskCollection)
+            {
+                disks.Add(new ManagedDiskExtended
+                {
+                    Disk = disk,
+                    SubscriptionName = subscription.Data.DisplayName,
+                    SubscriptionId = subscription.Data.SubscriptionId
+                });
+            }
+
+            return disks;
+        }
+
+        public async Task<List<ManagedDiskExtended>> FetchUnattachedDisksAsync()
+        {
+            var disks = await FetchAllDisksAsync();
+            return disks.Where(d => !d.IsAttached).ToList();
+        }
+
+        public async Task<List<ManagedDiskExtended>> FetchUnattachedDisksInSubscriptionAsync(string subscriptionId)
+        {
+            var disks = await FetchDisksInSubscriptionAsync(subscriptionId);
+            return disks.Where(d => !d.IsAttached).ToList();
+        }
+
+        public async Task<OperationResult> CreateSnapshotAsync(ManagedDiskResource disk, string snapshotName)
+        {
+            try
+            {
+                var subscription = _armClient.GetSubscriptionResource(new Azure.Core.ResourceIdentifier($"/subscriptions/{disk.Id.SubscriptionId}"));
+                var resourceGroupResponse = await subscription.GetResourceGroupAsync(disk.Id.ResourceGroupName);
+                var snapshotCollection = resourceGroupResponse.Value.GetSnapshots();
+
+                var snapshotData = new SnapshotData(disk.Data.Location)
+                {
+                    CreationData = new DiskCreationData(DiskCreateOption.Copy)
+                    {
+                        SourceResourceId = disk.Id
+                    },
+                    Sku = new SnapshotSku { Name = SnapshotStorageAccountType.StandardLrs }
+                };
+
+                var operation = await snapshotCollection.CreateOrUpdateAsync(Azure.WaitUntil.Completed, snapshotName, snapshotData);
+
+                return new OperationResult
+                {
+                    Success = operation.HasCompleted,
+                    Message = $"Snapshot '{snapshotName}' created for disk '{disk.Data.Name}'"
+                };
+            }
+            catch (Exception ex)
+            {
+                return new OperationResult
+                {
+                    Success = false,
+                    Message = $"Failed to create snapshot: {ex.Message}"
+                };
+            }
+        }
+
+        public async Task<OperationResult> DeleteDiskAsync(ManagedDiskResource disk)
+        {
+            try
+            {
+                if (disk.Data.ManagedBy != null)
+                {
+                    return new OperationResult
+                    {
+                        Success = false,
+                        Message = $"Disk '{disk.Data.Name}' is attached to a VM and cannot be deleted"
+                    };
+                }
+
+                var operation = await disk.DeleteAsync(Azure.WaitUntil.Completed);
+
+                return new OperationResult
+                {
+                    Success = true,
+                    Message = $"Disk '{disk.Data.Name}' deleted successfully"
+                };
+            }
+            catch (Exception ex)
+            {
+                return new OperationResult
+                {
+                    Success = false,
+                    Message = $"Failed to delete disk: {ex.Message}"
+                };
+            }
+        }
+    }
+}

--- a/src/Services/LockService.cs
+++ b/src/Services/LockService.cs
@@ -1,0 +1,192 @@
+using Azure.Identity;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.Resources.Models;
+using AzureOpsCLI.Interfaces;
+using AzureOpsCLI.Models;
+
+namespace AzureOpsCLI.Services
+{
+    public class LockService : ILockService
+    {
+        private readonly ArmClient _armClient;
+
+        public LockService()
+        {
+            _armClient = new ArmClient(new DefaultAzureCredential());
+        }
+
+        public async Task<List<ResourceLockExtended>> FetchAllLocksAsync()
+        {
+            var locks = new List<ResourceLockExtended>();
+
+            await foreach (var subscription in _armClient.GetSubscriptions())
+            {
+                await foreach (var rg in subscription.GetResourceGroups())
+                {
+                    await foreach (var lockResource in rg.GetManagementLocks())
+                    {
+                        locks.Add(new ResourceLockExtended
+                        {
+                            Lock = lockResource,
+                            SubscriptionName = subscription.Data.DisplayName,
+                            ResourceName = rg.Data.Name,
+                            ResourceType = "Resource Group"
+                        });
+                    }
+                }
+            }
+
+            return locks;
+        }
+
+        public async Task<List<ResourceLockExtended>> FetchLocksInSubscriptionAsync(string subscriptionId)
+        {
+            var locks = new List<ResourceLockExtended>();
+            var subscription = _armClient.GetSubscriptionResource(new Azure.Core.ResourceIdentifier($"/subscriptions/{subscriptionId}"));
+
+            await foreach (var rg in subscription.GetResourceGroups())
+            {
+                await foreach (var lockResource in rg.GetManagementLocks())
+                {
+                    locks.Add(new ResourceLockExtended
+                    {
+                        Lock = lockResource,
+                        SubscriptionName = subscription.Data.DisplayName,
+                        ResourceName = rg.Data.Name,
+                        ResourceType = "Resource Group"
+                    });
+                }
+            }
+
+            return locks;
+        }
+
+        public async Task<List<LockableResource>> FetchLockableResourcesAsync()
+        {
+            var resources = new List<LockableResource>();
+
+            await foreach (var subscription in _armClient.GetSubscriptions())
+            {
+                await foreach (var rg in subscription.GetResourceGroups())
+                {
+                    var hasLock = false;
+                    string? lockLevel = null;
+
+                    await foreach (var lockResource in rg.GetManagementLocks())
+                    {
+                        hasLock = true;
+                        lockLevel = lockResource.Data.Level.ToString();
+                        break;
+                    }
+
+                    resources.Add(new LockableResource
+                    {
+                        ResourceId = rg.Id.ToString(),
+                        Name = rg.Data.Name,
+                        Type = "Resource Group",
+                        SubscriptionName = subscription.Data.DisplayName,
+                        SubscriptionId = subscription.Data.SubscriptionId,
+                        ResourceGroup = rg.Data.Name,
+                        HasLock = hasLock,
+                        ExistingLockLevel = lockLevel
+                    });
+                }
+            }
+
+            return resources;
+        }
+
+        public async Task<List<LockableResource>> FetchLockableResourcesInSubscriptionAsync(string subscriptionId)
+        {
+            var resources = new List<LockableResource>();
+            var subscription = _armClient.GetSubscriptionResource(new Azure.Core.ResourceIdentifier($"/subscriptions/{subscriptionId}"));
+
+            await foreach (var rg in subscription.GetResourceGroups())
+            {
+                var hasLock = false;
+                string? lockLevel = null;
+
+                await foreach (var lockResource in rg.GetManagementLocks())
+                {
+                    hasLock = true;
+                    lockLevel = lockResource.Data.Level.ToString();
+                    break;
+                }
+
+                resources.Add(new LockableResource
+                {
+                    ResourceId = rg.Id.ToString(),
+                    Name = rg.Data.Name,
+                    Type = "Resource Group",
+                    SubscriptionName = subscription.Data.DisplayName,
+                    SubscriptionId = subscription.Data.SubscriptionId,
+                    ResourceGroup = rg.Data.Name,
+                    HasLock = hasLock,
+                    ExistingLockLevel = lockLevel
+                });
+            }
+
+            return resources;
+        }
+
+        public async Task<OperationResult> ApplyLockAsync(string resourceId, string lockName, string lockLevel)
+        {
+            try
+            {
+                var resourceIdentifier = new Azure.Core.ResourceIdentifier(resourceId);
+
+                ManagementLockLevel level = lockLevel.ToLower() switch
+                {
+                    "readonly" => ManagementLockLevel.ReadOnly,
+                    "cannotdelete" => ManagementLockLevel.CanNotDelete,
+                    _ => ManagementLockLevel.CanNotDelete
+                };
+
+                var lockData = new ManagementLockData(level)
+                {
+                    Notes = $"Lock created by AzureOpsCLI on {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC"
+                };
+
+                var rg = _armClient.GetResourceGroupResource(resourceIdentifier);
+                var lockCollection = rg.GetManagementLocks();
+                await lockCollection.CreateOrUpdateAsync(Azure.WaitUntil.Completed, lockName, lockData);
+
+                return new OperationResult
+                {
+                    Success = true,
+                    Message = $"Lock '{lockName}' ({lockLevel}) applied successfully"
+                };
+            }
+            catch (Exception ex)
+            {
+                return new OperationResult
+                {
+                    Success = false,
+                    Message = $"Failed to apply lock: {ex.Message}"
+                };
+            }
+        }
+
+        public async Task<OperationResult> RemoveLockAsync(ManagementLockResource lockResource)
+        {
+            try
+            {
+                await lockResource.DeleteAsync(Azure.WaitUntil.Completed);
+                return new OperationResult
+                {
+                    Success = true,
+                    Message = $"Lock '{lockResource.Data.Name}' removed successfully"
+                };
+            }
+            catch (Exception ex)
+            {
+                return new OperationResult
+                {
+                    Success = false,
+                    Message = $"Failed to remove lock: {ex.Message}"
+                };
+            }
+        }
+    }
+}

--- a/src/Services/MetricsService.cs
+++ b/src/Services/MetricsService.cs
@@ -1,0 +1,226 @@
+using Azure.Identity;
+using Azure.Monitor.Query;
+using Azure.Monitor.Query.Models;
+using Azure.ResourceManager;
+using Azure.ResourceManager.Compute;
+using AzureOpsCLI.Interfaces;
+
+namespace AzureOpsCLI.Services
+{
+    public class MetricsService : IMetricsService
+    {
+        private readonly ArmClient _armClient;
+        private readonly MetricsQueryClient _metricsClient;
+
+        public MetricsService()
+        {
+            var credential = new DefaultAzureCredential();
+            _armClient = new ArmClient(credential);
+            _metricsClient = new MetricsQueryClient(credential);
+        }
+
+        public async Task<List<VmMetrics>> FetchAllVMMetricsAsync()
+        {
+            var metrics = new List<VmMetrics>();
+
+            await foreach (var subscription in _armClient.GetSubscriptions())
+            {
+                var vms = subscription.GetVirtualMachinesAsync();
+                await foreach (var vm in vms)
+                {
+                    var vmMetrics = await GetVmMetricsAsync(vm, subscription.Data.DisplayName);
+                    if (vmMetrics != null)
+                    {
+                        metrics.Add(vmMetrics);
+                    }
+                }
+            }
+
+            return metrics;
+        }
+
+        public async Task<List<VmMetrics>> FetchVMMetricsInSubscriptionAsync(string subscriptionId)
+        {
+            var metrics = new List<VmMetrics>();
+            var subscription = _armClient.GetSubscriptionResource(new Azure.Core.ResourceIdentifier($"/subscriptions/{subscriptionId}"));
+
+            var vms = subscription.GetVirtualMachinesAsync();
+            await foreach (var vm in vms)
+            {
+                var vmMetrics = await GetVmMetricsAsync(vm, subscription.Data.DisplayName);
+                if (vmMetrics != null)
+                {
+                    metrics.Add(vmMetrics);
+                }
+            }
+
+            return metrics;
+        }
+
+        public async Task<List<VmssMetrics>> FetchAllVMSSMetricsAsync()
+        {
+            var metrics = new List<VmssMetrics>();
+
+            await foreach (var subscription in _armClient.GetSubscriptions())
+            {
+                var vmssCollection = subscription.GetVirtualMachineScaleSetsAsync();
+                await foreach (var vmss in vmssCollection)
+                {
+                    var vmssMetrics = await GetVmssMetricsAsync(vmss, subscription.Data.DisplayName);
+                    if (vmssMetrics != null)
+                    {
+                        metrics.Add(vmssMetrics);
+                    }
+                }
+            }
+
+            return metrics;
+        }
+
+        public async Task<List<VmssMetrics>> FetchVMSSMetricsInSubscriptionAsync(string subscriptionId)
+        {
+            var metrics = new List<VmssMetrics>();
+            var subscription = _armClient.GetSubscriptionResource(new Azure.Core.ResourceIdentifier($"/subscriptions/{subscriptionId}"));
+
+            var vmssCollection = subscription.GetVirtualMachineScaleSetsAsync();
+            await foreach (var vmss in vmssCollection)
+            {
+                var vmssMetrics = await GetVmssMetricsAsync(vmss, subscription.Data.DisplayName);
+                if (vmssMetrics != null)
+                {
+                    metrics.Add(vmssMetrics);
+                }
+            }
+
+            return metrics;
+        }
+
+        private async Task<VmMetrics?> GetVmMetricsAsync(VirtualMachineResource vm, string subscriptionName)
+        {
+            try
+            {
+                var resourceId = vm.Id.ToString();
+                var timeSpan = new QueryTimeRange(TimeSpan.FromHours(1));
+
+                var response = await _metricsClient.QueryResourceAsync(
+                    resourceId,
+                    new[] { "Percentage CPU", "Available Memory Bytes", "Disk Read Bytes", "Disk Write Bytes", "Network In Total", "Network Out Total" },
+                    new MetricsQueryOptions
+                    {
+                        Granularity = TimeSpan.FromMinutes(5),
+                        TimeRange = timeSpan
+                    });
+
+                var result = new VmMetrics
+                {
+                    Name = vm.Data.Name,
+                    SubscriptionName = subscriptionName,
+                    ResourceGroup = vm.Id.ResourceGroupName ?? string.Empty,
+                    Location = vm.Data.Location.ToString()
+                };
+
+                foreach (var metric in response.Value.Metrics)
+                {
+                    var latestValue = metric.TimeSeries
+                        .SelectMany(ts => ts.Values)
+                        .Where(v => v.Average.HasValue)
+                        .OrderByDescending(v => v.TimeStamp)
+                        .FirstOrDefault()?.Average;
+
+                    switch (metric.Name)
+                    {
+                        case "Percentage CPU":
+                            result.CpuPercentage = latestValue;
+                            break;
+                        case "Available Memory Bytes":
+                            result.MemoryPercentage = latestValue;
+                            break;
+                        case "Disk Read Bytes":
+                            result.DiskReadBytesPerSec = latestValue;
+                            break;
+                        case "Disk Write Bytes":
+                            result.DiskWriteBytesPerSec = latestValue;
+                            break;
+                        case "Network In Total":
+                            result.NetworkInBytesPerSec = latestValue;
+                            break;
+                        case "Network Out Total":
+                            result.NetworkOutBytesPerSec = latestValue;
+                            break;
+                    }
+                }
+
+                return result;
+            }
+            catch
+            {
+                return new VmMetrics
+                {
+                    Name = vm.Data.Name,
+                    SubscriptionName = subscriptionName,
+                    ResourceGroup = vm.Id.ResourceGroupName ?? string.Empty,
+                    Location = vm.Data.Location.ToString()
+                };
+            }
+        }
+
+        private async Task<VmssMetrics?> GetVmssMetricsAsync(VirtualMachineScaleSetResource vmss, string subscriptionName)
+        {
+            try
+            {
+                var resourceId = vmss.Id.ToString();
+                var timeSpan = new QueryTimeRange(TimeSpan.FromHours(1));
+
+                var response = await _metricsClient.QueryResourceAsync(
+                    resourceId,
+                    new[] { "Percentage CPU", "Available Memory Bytes" },
+                    new MetricsQueryOptions
+                    {
+                        Granularity = TimeSpan.FromMinutes(5),
+                        TimeRange = timeSpan
+                    });
+
+                var result = new VmssMetrics
+                {
+                    Name = vmss.Data.Name,
+                    SubscriptionName = subscriptionName,
+                    ResourceGroup = vmss.Id.ResourceGroupName ?? string.Empty,
+                    Location = vmss.Data.Location.ToString(),
+                    InstanceCount = vmss.Data.Sku?.Capacity != null ? (int)vmss.Data.Sku.Capacity : 0
+                };
+
+                foreach (var metric in response.Value.Metrics)
+                {
+                    var latestValue = metric.TimeSeries
+                        .SelectMany(ts => ts.Values)
+                        .Where(v => v.Average.HasValue)
+                        .OrderByDescending(v => v.TimeStamp)
+                        .FirstOrDefault()?.Average;
+
+                    switch (metric.Name)
+                    {
+                        case "Percentage CPU":
+                            result.AvgCpuPercentage = latestValue;
+                            break;
+                        case "Available Memory Bytes":
+                            result.AvgMemoryPercentage = latestValue;
+                            break;
+                    }
+                }
+
+                return result;
+            }
+            catch
+            {
+                return new VmssMetrics
+                {
+                    Name = vmss.Data.Name,
+                    SubscriptionName = subscriptionName,
+                    ResourceGroup = vmss.Id.ResourceGroupName ?? string.Empty,
+                    Location = vmss.Data.Location.ToString(),
+                    InstanceCount = vmss.Data.Sku?.Capacity != null ? (int)vmss.Data.Sku.Capacity : 0
+                };
+            }
+        }
+    }
+}

--- a/src/Services/RGService.cs
+++ b/src/Services/RGService.cs
@@ -79,12 +79,19 @@ namespace AzureOpsCLI.Services
             return rgs;
         }
 
-        public async Task<bool> CreateResourceGroupAsync(string subscriptionId, string resourceGroupName, string location)
+        public async Task<bool> CreateResourceGroupAsync(string subscriptionId, string resourceGroupName, string location, Dictionary<string, string>? tags = null)
         {
             try
             {
                 SubscriptionResource subscription = await _armClient.GetSubscriptions().GetAsync(subscriptionId);
                 ResourceGroupData rgData = new ResourceGroupData(location);
+                if (tags != null)
+                {
+                    foreach (var tag in tags)
+                    {
+                        rgData.Tags.Add(tag.Key, tag.Value);
+                    }
+                }
                 await subscription.GetResourceGroups().CreateOrUpdateAsync(WaitUntil.Completed, resourceGroupName, rgData);
                 return true;
             }

--- a/src/Settings/ListCommandSettings.cs
+++ b/src/Settings/ListCommandSettings.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace AzureOpsCLI.Settings
+{
+    public class ListCommandSettings : CommandSettings
+    {
+        [CommandOption("-f|--filter <FILTER>")]
+        [Description("Filter results by name (case-insensitive contains match)")]
+        public string? Filter { get; set; }
+
+        [CommandOption("-e|--export <FORMAT>")]
+        [Description("Export results to file (csv or json)")]
+        public string? ExportFormat { get; set; }
+    }
+}


### PR DESCRIPTION
New features:
- Add disk management commands (list, list-unattached, snapshot, delete)
- Add resource lock commands (list, apply, remove)
- Add VM metrics commands (CPU, memory, disk, network)
- Add --tags option to resource group create command
- Add list-unattached command to show only orphaned disks

Updates:
- Update InfoCommand with new command hierarchy
- Update README with new features and examples
- Fix typos in VMSS list command filenames